### PR TITLE
feat(ui): add infinity scroll pagination option to list components

### DIFF
--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_list.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_list.dart
@@ -92,7 +92,6 @@ class AppUsageListState extends State<AppUsageList> with PaginationMixin<AppUsag
     super.initState();
     _currentFilters = _captureCurrentFilters();
     _setupEventListeners();
-    _setupEventListeners();
     _getList(isRefresh: true);
   }
 

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_tag_rule_list.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_tag_rule_list.dart
@@ -16,12 +16,14 @@ import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_s
 import 'package:whph/presentation/ui/shared/components/icon_overlay.dart';
 import 'package:whph/main.dart';
 import 'package:whph/presentation/ui/shared/enums/pagination_mode.dart';
+import 'package:whph/presentation/ui/shared/mixins/pagination_mixin.dart';
 
-class AppUsageTagRuleList extends StatefulWidget {
+class AppUsageTagRuleList extends StatefulWidget implements IPaginatedWidget {
   final Mediator mediator;
   final Function(String id)? onRuleSelected;
   final List<String>? filterByTags;
   final int pageSize;
+  @override
   final PaginationMode paginationMode;
 
   const AppUsageTagRuleList({
@@ -37,7 +39,7 @@ class AppUsageTagRuleList extends StatefulWidget {
   State<AppUsageTagRuleList> createState() => AppUsageTagRuleListState();
 }
 
-class AppUsageTagRuleListState extends State<AppUsageTagRuleList> {
+class AppUsageTagRuleListState extends State<AppUsageTagRuleList> with PaginationMixin<AppUsageTagRuleList> {
   final ScrollController _scrollController = ScrollController();
   GetListAppUsageTagRulesQueryResponse? _ruleList;
   bool _isLoading = false;
@@ -45,52 +47,24 @@ class AppUsageTagRuleListState extends State<AppUsageTagRuleList> {
   final _appUsagesService = container.resolve<AppUsagesService>();
   double? _savedScrollPosition;
 
-  // Infinity scroll state
-  bool _isLoadingMore = false;
+  @override
+  ScrollController get scrollController => _scrollController;
+
+  @override
+  bool get hasNextPage => _ruleList?.hasNext ?? false;
 
   @override
   void initState() {
     super.initState();
     _setupEventListeners();
     _loadRules(isRefresh: true);
-    _setupScrollListener();
   }
 
   @override
   void dispose() {
     _removeEventListeners();
-    _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     super.dispose();
-  }
-
-  void _setupScrollListener() {
-    if (widget.paginationMode == PaginationMode.infinityScroll) {
-      _scrollController.addListener(_onScroll);
-    }
-  }
-
-  void _onScroll() {
-    if (widget.paginationMode != PaginationMode.infinityScroll) return;
-    if (_isLoadingMore || _ruleList == null || !_ruleList!.hasNext) return;
-
-    final maxScroll = _scrollController.position.maxScrollExtent;
-    final currentScroll = _scrollController.position.pixels;
-    final threshold = maxScroll * 0.8;
-
-    if (currentScroll >= threshold) {
-      _loadMoreInfinityScroll();
-    }
-  }
-
-  Future<void> _loadMoreInfinityScroll() async {
-    if (_isLoadingMore || _ruleList == null || !_ruleList!.hasNext) return;
-
-    setState(() => _isLoadingMore = true);
-    await _loadRules(pageIndex: _ruleList!.pageIndex + 1);
-    if (mounted) {
-      setState(() => _isLoadingMore = false);
-    }
   }
 
   void _setupEventListeners() {
@@ -177,7 +151,7 @@ class AppUsageTagRuleListState extends State<AppUsageTagRuleList> {
           // For infinity scroll: check if viewport needs more content
           if (widget.paginationMode == PaginationMode.infinityScroll && (_ruleList?.hasNext ?? false)) {
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              _checkAndFillViewport();
+              checkAndFillViewport();
             });
           }
         }
@@ -295,9 +269,9 @@ class AppUsageTagRuleListState extends State<AppUsageTagRuleList> {
           if (_ruleList!.hasNext && widget.paginationMode == PaginationMode.loadMore)
             Padding(
               padding: const EdgeInsets.only(top: AppTheme.size2XSmall),
-              child: Center(child: LoadMoreButton(onPressed: _onLoadMore)),
+              child: Center(child: LoadMoreButton(onPressed: onLoadMore)),
             ),
-          if (_ruleList!.hasNext && widget.paginationMode == PaginationMode.infinityScroll && _isLoadingMore)
+          if (_ruleList!.hasNext && widget.paginationMode == PaginationMode.infinityScroll && isLoadingMore)
             const Padding(
               padding: EdgeInsets.symmetric(vertical: AppTheme.sizeMedium),
               child: Center(child: CircularProgressIndicator()),
@@ -307,7 +281,8 @@ class AppUsageTagRuleListState extends State<AppUsageTagRuleList> {
     );
   }
 
-  Future<void> _onLoadMore() async {
+  @override
+  Future<void> onLoadMore() async {
     if (_ruleList == null || !_ruleList!.hasNext) return;
 
     _saveScrollPosition();
@@ -352,16 +327,6 @@ class AppUsageTagRuleListState extends State<AppUsageTagRuleList> {
           // The component will refresh automatically through event listener
         },
       );
-    }
-  }
-
-  void _checkAndFillViewport() {
-    if (!mounted || _isLoadingMore || _ruleList == null || !_ruleList!.hasNext) return;
-    if (!_scrollController.hasClients) return;
-
-    final maxScroll = _scrollController.position.maxScrollExtent;
-    if (maxScroll <= 0) {
-      _loadMoreInfinityScroll();
     }
   }
 }

--- a/src/lib/presentation/ui/features/app_usages/pages/app_usage_rules_page.dart
+++ b/src/lib/presentation/ui/features/app_usages/pages/app_usage_rules_page.dart
@@ -11,6 +11,7 @@ import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_s
 import 'package:whph/presentation/ui/features/app_usages/constants/app_usage_translation_keys.dart';
 import 'package:whph/presentation/ui/shared/components/styled_icon.dart';
 import 'package:whph/presentation/ui/shared/components/custom_tab_bar.dart';
+import 'package:whph/presentation/ui/shared/enums/pagination_mode.dart';
 
 class AppUsageRulesPage extends StatefulWidget {
   static const String route = '/app-usages/rules';
@@ -153,6 +154,7 @@ class _AppUsageRulesPageState extends State<AppUsageRulesPage> with SingleTicker
                           title: _translationService.translate(AppUsageTranslationKeys.existingRules),
                           child: AppUsageTagRuleList(
                             mediator: _mediator,
+                            paginationMode: PaginationMode.infinityScroll,
                           ),
                         ),
                       ],
@@ -173,7 +175,9 @@ class _AppUsageRulesPageState extends State<AppUsageRulesPage> with SingleTicker
                         _buildListSection(
                           icon: Icons.list_alt,
                           title: _translationService.translate(AppUsageTranslationKeys.existingRules),
-                          child: AppUsageIgnoreRuleList(),
+                          child: AppUsageIgnoreRuleList(
+                            paginationMode: PaginationMode.infinityScroll,
+                          ),
                         ),
                       ],
                     ),

--- a/src/lib/presentation/ui/features/app_usages/pages/app_usage_view_page.dart
+++ b/src/lib/presentation/ui/features/app_usages/pages/app_usage_view_page.dart
@@ -8,6 +8,7 @@ import 'package:whph/core/application/features/app_usages/services/abstraction/i
 import 'package:whph/presentation/ui/features/app_usages/components/app_usage_list_options.dart';
 import 'package:whph/presentation/ui/features/app_usages/components/app_usage_list.dart';
 import 'package:whph/presentation/ui/features/app_usages/pages/app_usage_details_page.dart';
+import 'package:whph/presentation/ui/shared/enums/pagination_mode.dart';
 import 'package:whph/presentation/ui/features/app_usages/pages/app_usage_rules_page.dart';
 import 'package:whph/presentation/ui/features/app_usages/services/app_usages_service.dart';
 import 'package:whph/presentation/ui/features/app_usages/pages/android_app_usage_debug_page.dart';
@@ -327,7 +328,8 @@ class _AppUsageViewPageState extends State<AppUsageViewPage> {
                       filterStartDate: _getEffectiveStartDate(),
                       filterEndDate: _getEffectiveEndDate(),
                       filterByDevices: _filterState.devices,
-                      showComparison: _filterState.showComparison),
+                      showComparison: _filterState.showComparison,
+                      paginationMode: PaginationMode.infinityScroll),
                 ),
             ],
           ],

--- a/src/lib/presentation/ui/features/habits/components/habits_list.dart
+++ b/src/lib/presentation/ui/features/habits/components/habits_list.dart
@@ -100,7 +100,6 @@ class HabitsListState extends State<HabitsList> with PaginationMixin<HabitsList>
     _dragStateNotifier = DragStateNotifier();
     _currentFilters = _captureCurrentFilters();
     _getHabits();
-    _getHabits();
     _setupEventListeners();
   }
 

--- a/src/lib/presentation/ui/features/habits/pages/habits_page.dart
+++ b/src/lib/presentation/ui/features/habits/pages/habits_page.dart
@@ -6,6 +6,7 @@ import 'package:whph/main.dart';
 import 'package:whph/presentation/ui/features/habits/components/habit_add_button.dart';
 import 'package:whph/presentation/ui/features/habits/components/habit_list_options.dart';
 import 'package:whph/presentation/ui/features/habits/components/habits_list.dart';
+import 'package:whph/presentation/ui/shared/enums/pagination_mode.dart';
 import 'package:whph/presentation/ui/features/habits/models/habit_list_style.dart';
 import 'package:whph/presentation/ui/features/habits/constants/habit_defaults.dart';
 import 'package:whph/presentation/ui/features/habits/constants/habit_ui_constants.dart';
@@ -375,6 +376,7 @@ class _HabitsPageState extends State<HabitsPage> {
                   enableReordering: _sortConfig.useCustomOrder,
                   forceOriginalLayout: _forceOriginalLayout,
                   useParentScroll: false,
+                  paginationMode: PaginationMode.infinityScroll,
                   onClickHabit: (item) {
                     _openDetails(item.id, context);
                   },

--- a/src/lib/presentation/ui/features/notes/pages/notes_page.dart
+++ b/src/lib/presentation/ui/features/notes/pages/notes_page.dart
@@ -6,6 +6,7 @@ import 'package:whph/main.dart';
 import 'package:whph/presentation/ui/features/notes/components/note_add_button.dart';
 import 'package:whph/presentation/ui/features/notes/components/note_list_options.dart';
 import 'package:whph/presentation/ui/features/notes/components/notes_list.dart';
+import 'package:whph/presentation/ui/shared/enums/pagination_mode.dart';
 import 'package:whph/presentation/ui/features/notes/constants/note_translation_keys.dart';
 import 'package:whph/presentation/ui/features/notes/pages/note_details_page.dart';
 import 'package:whph/presentation/ui/shared/components/kebab_menu.dart';
@@ -202,6 +203,7 @@ class _NotesPageState extends State<NotesPage> with AutomaticKeepAliveClientMixi
                   sortConfig: _sortConfig,
                   onClickNote: _openDetails,
                   onList: _onDataListed,
+                  paginationMode: PaginationMode.infinityScroll,
                 ),
               ),
           ],

--- a/src/lib/presentation/ui/features/tags/pages/tags_page.dart
+++ b/src/lib/presentation/ui/features/tags/pages/tags_page.dart
@@ -12,6 +12,7 @@ import 'package:whph/presentation/ui/features/tags/components/tag_list_options.d
 import 'package:whph/presentation/ui/features/tags/components/tag_time_chart.dart';
 import 'package:whph/presentation/ui/features/tags/components/tags_list.dart';
 import 'package:whph/presentation/ui/shared/models/sort_config.dart';
+import 'package:whph/presentation/ui/shared/enums/pagination_mode.dart';
 import 'package:whph/presentation/ui/features/tags/pages/tag_details_page.dart';
 import 'package:whph/presentation/ui/shared/components/responsive_scaffold_layout.dart';
 import 'package:whph/presentation/ui/shared/models/dropdown_option.dart';
@@ -322,6 +323,7 @@ class _TagsPageState extends State<TagsPage> {
                     search: _searchFilterQuery,
                     showArchived: _showArchived,
                     sortConfig: _sortConfig,
+                    paginationMode: PaginationMode.infinityScroll,
                   ),
               ],
             ),

--- a/src/lib/presentation/ui/features/tasks/components/tasks_list.dart
+++ b/src/lib/presentation/ui/features/tasks/components/tasks_list.dart
@@ -18,8 +18,9 @@ import 'package:whph/presentation/ui/features/tasks/constants/task_translation_k
 import 'package:whph/presentation/ui/shared/components/icon_overlay.dart';
 import 'package:whph/presentation/ui/shared/enums/pagination_mode.dart';
 import 'package:whph/presentation/ui/shared/providers/drag_state_provider.dart';
+import 'package:whph/presentation/ui/shared/mixins/pagination_mixin.dart';
 
-class TaskList extends StatefulWidget {
+class TaskList extends StatefulWidget implements IPaginatedWidget {
   final int pageSize;
 
   // Filter props to match query parameters
@@ -56,6 +57,7 @@ class TaskList extends StatefulWidget {
   final Key? rebuildKey;
   final SortConfig<TaskSortFields>? sortConfig;
   final void Function()? onReorderComplete;
+  @override
   final PaginationMode paginationMode;
 
   const TaskList({
@@ -99,7 +101,7 @@ class TaskList extends StatefulWidget {
   State<TaskList> createState() => TaskListState();
 }
 
-class TaskListState extends State<TaskList> {
+class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
   final _mediator = container.resolve<Mediator>();
   final _translationService = container.resolve<ITranslationService>();
   final _tasksService = container.resolve<TasksService>();
@@ -111,8 +113,11 @@ class TaskListState extends State<TaskList> {
   // Drag state notifier for reorderable list
   late final DragStateNotifier _dragStateNotifier;
 
-  // Infinity scroll state
-  bool _isLoadingMore = false;
+  @override
+  ScrollController get scrollController => _scrollController;
+
+  @override
+  bool get hasNextPage => _tasks?.hasNext ?? false;
 
   @override
   void initState() {
@@ -120,45 +125,14 @@ class TaskListState extends State<TaskList> {
     _dragStateNotifier = DragStateNotifier();
     _getTasksList();
     _setupEventListeners();
-    _setupScrollListener();
   }
 
   @override
   void dispose() {
     _dragStateNotifier.dispose();
     _removeEventListeners();
-    _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     super.dispose();
-  }
-
-  void _setupScrollListener() {
-    if (widget.paginationMode == PaginationMode.infinityScroll) {
-      _scrollController.addListener(_onScroll);
-    }
-  }
-
-  void _onScroll() {
-    if (widget.paginationMode != PaginationMode.infinityScroll) return;
-    if (_isLoadingMore || _tasks == null || !_tasks!.hasNext) return;
-
-    final maxScroll = _scrollController.position.maxScrollExtent;
-    final currentScroll = _scrollController.position.pixels;
-    final threshold = maxScroll * 0.8; // Load more when 80% scrolled
-
-    if (currentScroll >= threshold) {
-      _loadMoreInfinityScroll();
-    }
-  }
-
-  Future<void> _loadMoreInfinityScroll() async {
-    if (_isLoadingMore || _tasks == null || !_tasks!.hasNext) return;
-
-    setState(() => _isLoadingMore = true);
-    await _getTasksList(pageIndex: _tasks!.pageIndex + 1);
-    if (mounted) {
-      setState(() => _isLoadingMore = false);
-    }
   }
 
   void _setupEventListeners() {
@@ -326,23 +300,11 @@ class TaskListState extends State<TaskList> {
         // For infinity scroll: check if viewport needs more content
         if (widget.paginationMode == PaginationMode.infinityScroll && _tasks!.hasNext) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            _checkAndFillViewport();
+            checkAndFillViewport();
           });
         }
       },
     );
-  }
-
-  /// Checks if viewport has room for more content and auto-fetches if needed.
-  void _checkAndFillViewport() {
-    if (!mounted || _isLoadingMore || _tasks == null || !_tasks!.hasNext) return;
-    if (!_scrollController.hasClients) return;
-
-    final maxScroll = _scrollController.position.maxScrollExtent;
-    // If there's no scroll needed (maxScroll is 0 or very small), fetch more
-    if (maxScroll <= 0) {
-      _loadMoreInfinityScroll();
-    }
   }
 
   void _onTaskCompleted() {
@@ -470,7 +432,8 @@ class TaskListState extends State<TaskList> {
     }
   }
 
-  Future<void> _onLoadMore() async {
+  @override
+  Future<void> onLoadMore() async {
     if (_tasks == null || !_tasks!.hasNext) return;
 
     _saveScrollPosition();
@@ -601,10 +564,10 @@ class TaskListState extends State<TaskList> {
               padding: const EdgeInsets.only(top: AppTheme.size2XSmall),
               child: Center(
                   child: LoadMoreButton(
-                onPressed: _onLoadMore,
+                onPressed: onLoadMore,
               )),
             ),
-          if (_tasks!.hasNext && widget.paginationMode == PaginationMode.infinityScroll && _isLoadingMore)
+          if (_tasks!.hasNext && widget.paginationMode == PaginationMode.infinityScroll && isLoadingMore)
             Padding(
               key: const ValueKey('loading_indicator'),
               padding: const EdgeInsets.symmetric(vertical: AppTheme.sizeMedium),
@@ -616,7 +579,7 @@ class TaskListState extends State<TaskList> {
       final taskCards = _buildTaskCards();
       final showLoadMore = _tasks!.hasNext && widget.paginationMode == PaginationMode.loadMore;
       final showInfinityLoading =
-          _tasks!.hasNext && widget.paginationMode == PaginationMode.infinityScroll && _isLoadingMore;
+          _tasks!.hasNext && widget.paginationMode == PaginationMode.infinityScroll && isLoadingMore;
       final extraItemCount = (showLoadMore || showInfinityLoading) ? 1 : 0;
 
       return ListView.builder(
@@ -636,7 +599,7 @@ class TaskListState extends State<TaskList> {
               padding: const EdgeInsets.only(top: AppTheme.size2XSmall),
               child: Center(
                   child: LoadMoreButton(
-                onPressed: _onLoadMore,
+                onPressed: onLoadMore,
               )),
             );
           } else if (showInfinityLoading) {

--- a/src/lib/presentation/ui/features/tasks/pages/tasks_page.dart
+++ b/src/lib/presentation/ui/features/tasks/pages/tasks_page.dart
@@ -9,6 +9,7 @@ import 'package:whph/presentation/ui/features/tasks/components/task_add_button.d
 import 'package:whph/presentation/ui/features/tasks/components/task_add_floating_button.dart';
 import 'package:whph/presentation/ui/features/tasks/components/tasks_list.dart';
 import 'package:whph/presentation/ui/features/tasks/pages/task_details_page.dart';
+import 'package:whph/presentation/ui/shared/enums/pagination_mode.dart';
 import 'package:whph/presentation/ui/shared/components/loading_overlay.dart';
 import 'package:whph/presentation/ui/shared/components/responsive_scaffold_layout.dart';
 import 'package:acore/utils/dialog_size.dart';
@@ -413,6 +414,7 @@ class _TasksPageState extends State<TasksPage> with AutomaticKeepAliveClientMixi
                   forceOriginalLayout: _forceOriginalLayout,
                   sortConfig: _sortConfig,
                   useParentScroll: false,
+                  paginationMode: PaginationMode.infinityScroll,
                 ),
               ),
           ],

--- a/src/lib/presentation/ui/shared/enums/pagination_mode.dart
+++ b/src/lib/presentation/ui/shared/enums/pagination_mode.dart
@@ -1,0 +1,9 @@
+/// Defines the pagination mode for list components.
+enum PaginationMode {
+  /// Show a "Load More" button at the bottom of the list.
+  /// User must tap to load more items.
+  loadMore,
+
+  /// Automatically load more items when the user scrolls near the bottom.
+  infinityScroll,
+}

--- a/src/lib/presentation/ui/shared/mixins/pagination_mixin.dart
+++ b/src/lib/presentation/ui/shared/mixins/pagination_mixin.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:whph/presentation/ui/shared/enums/pagination_mode.dart';
+
+/// Interface for widgets that support pagination mode
+abstract class IPaginatedWidget {
+  PaginationMode get paginationMode;
+}
+
+/// Mixin to handle infinity scroll pagination logic
+mixin PaginationMixin<T extends StatefulWidget> on State<T> {
+  // Required dependencies to be implemented by the host state
+  ScrollController get scrollController;
+  Future<void> onLoadMore();
+  bool get hasNextPage;
+
+  // Internal state
+  bool _isLoadingMore = false;
+  bool get isLoadingMore => _isLoadingMore;
+
+  static const double _infinityScrollThresholdRatio = 0.8;
+
+  @override
+  void initState() {
+    super.initState();
+    _setupScrollListener();
+  }
+
+  @override
+  void didUpdateWidget(T oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget is IPaginatedWidget && oldWidget is IPaginatedWidget) {
+      final newMode = (widget as IPaginatedWidget).paginationMode;
+      final oldMode = (oldWidget as IPaginatedWidget).paginationMode;
+      if (newMode != oldMode) {
+        _updateScrollListener(oldMode, newMode);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _removeScrollListener();
+    super.dispose();
+  }
+
+  void _setupScrollListener() {
+    if (widget is IPaginatedWidget && (widget as IPaginatedWidget).paginationMode == PaginationMode.infinityScroll) {
+      scrollController.addListener(_onScroll);
+    }
+  }
+
+  void _removeScrollListener() {
+    try {
+      scrollController.removeListener(_onScroll);
+    } catch (_) {
+      // Ignore if controller already disposed or not attached
+    }
+  }
+
+  void _updateScrollListener(PaginationMode oldMode, PaginationMode newMode) {
+    if (oldMode == PaginationMode.infinityScroll) {
+      _removeScrollListener();
+    }
+    if (newMode == PaginationMode.infinityScroll) {
+      scrollController.addListener(_onScroll);
+    }
+  }
+
+  void _onScroll() {
+    if (!_shouldLoadMore()) return;
+
+    if (!scrollController.hasClients) return;
+
+    final maxScroll = scrollController.position.maxScrollExtent;
+    final currentScroll = scrollController.position.pixels;
+    final threshold = maxScroll * _infinityScrollThresholdRatio;
+
+    if (currentScroll >= threshold) {
+      loadMoreInfinityScroll();
+    }
+  }
+
+  bool _shouldLoadMore() {
+    if (widget is IPaginatedWidget && (widget as IPaginatedWidget).paginationMode != PaginationMode.infinityScroll) {
+      return false;
+    }
+    // Prevent race condition: do not load if already loading
+    if (_isLoadingMore || !hasNextPage) return false;
+    return true;
+  }
+
+  Future<void> loadMoreInfinityScroll() async {
+    // Double check to prevent race condition
+    if (_isLoadingMore || !hasNextPage) return;
+
+    setState(() => _isLoadingMore = true);
+    try {
+      await onLoadMore();
+    } catch (e) {
+      // Robust error handling: Log error or allow retry
+      debugPrint('Error in infinity scroll load: $e');
+    } finally {
+      if (mounted) {
+        setState(() => _isLoadingMore = false);
+      }
+    }
+  }
+
+  /// Checks if viewport is full and loads more if needed.
+  /// Should be called after data load.
+  void checkAndFillViewport() {
+    if (!mounted || _isLoadingMore || !hasNextPage) return;
+    if (!scrollController.hasClients) return;
+
+    // Use extentAfter/maxScrollExtent to determine if content fills the viewport.
+    // If maxScrollExtent is very small, it means the content fits in the viewport
+    // and we might need to load more to trigger the scroll capability.
+    // '10' is a small epsilon to account for potential minor layout variations.
+    if (scrollController.position.maxScrollExtent <= 10) {
+      loadMoreInfinityScroll();
+    }
+  }
+}


### PR DESCRIPTION
## 🎯 Context
This PR adds infinity scroll pagination as an alternative to the existing load more button across all list components in the app.

## 🛠️ Major Changes
- Introduced PaginationMode enum with loadMore and infinityScroll options
- Implemented infinity scroll functionality in all list components (app usage, habits, notes, tags, and tasks)
- Added scroll listeners with threshold detection for auto-loading
- Maintained backward compatibility with existing load more buttons
- Updated 14 files with 516 additions and 21 deletions

## 🧪 Testing
- [x] Ran fvm flutter test locally.

## Summary by Sourcery

Add an optional infinity scroll pagination mode alongside the existing load-more behavior and wire it into key list-based screens.

New Features:
- Introduce a PaginationMode enum to toggle between load-more and infinity-scroll behaviors for list components.
- Enable infinity scroll with automatic page loading and loading indicators across habits, tasks, notes, tags, app usage lists, and app usage rule lists.
- Update habits, tasks, notes, tags, and app usage pages to opt into infinity scroll for their primary lists.

Enhancements:
- Preserve backward compatibility by defaulting all lists to the existing load-more pagination mode when no pagination option is specified.