### PR TITLE
fix: resolve card background positioning corruption

### DIFF
--- a/src/lib/presentation/ui/features/calendar/pages/today_page.dart
+++ b/src/lib/presentation/ui/features/calendar/pages/today_page.dart
@@ -59,9 +59,7 @@ class _TodayPageState extends State<TodayPage> with SingleTickerProviderStateMix
   // Tour keys
   final GlobalKey _mainListOptionsKey = GlobalKey();
   final GlobalKey _habitsSectionKey = GlobalKey();
-  final GlobalKey _habitsListKey = GlobalKey();
   final GlobalKey _tasksSectionKey = GlobalKey();
-  final GlobalKey _tasksListKey = GlobalKey();
   final GlobalKey _mainContentKey = GlobalKey();
   final GlobalKey _timeChartSectionKey = GlobalKey();
   final GlobalKey _marathonButtonKey = GlobalKey();
@@ -420,7 +418,8 @@ class _TodayPageState extends State<TodayPage> with SingleTickerProviderStateMix
                     // Habits list
                     if (_habitListOptionSettingsLoaded)
                       HabitsList(
-                        key: _habitsListKey,
+                        key: ValueKey(
+                            'habits_list_${_habitListStyle}_$_remainingHabits${_selectedTagFilter?.join(',') ?? 'noTags'}${_showNoTagsFilter ? 'none' : 'some'}'),
                         pageSize: 5,
                         style: _habitListStyle,
                         filterByTags: _showNoTagsFilter ? [] : _selectedTagFilter,
@@ -510,7 +509,8 @@ class _TodayPageState extends State<TodayPage> with SingleTickerProviderStateMix
                     // Tasks list
                     if (_taskListOptionSettingsLoaded)
                       TaskList(
-                        key: _tasksListKey,
+                        key: ValueKey(
+                            'task_list_${_taskForceOriginalLayout}_$_remainingTasks${_selectedTagFilter?.join(',') ?? 'noTags'}${_showNoTagsFilter ? 'none' : 'some'}${_showCompletedTasks ? 'completed' : 'incomplete'}${_taskSearchQuery ?? 'nosearch'}'),
                         filterByCompleted: _showCompletedTasks,
                         filterByTags: _showNoTagsFilter ? [] : _selectedTagFilter,
                         filterNoTags: _showNoTagsFilter,

--- a/src/lib/presentation/ui/features/habits/components/habit_card/habit_card.dart
+++ b/src/lib/presentation/ui/features/habits/components/habit_card/habit_card.dart
@@ -207,45 +207,51 @@ class _HabitCardState extends State<HabitCard> {
       button: true,
       label: '${widget.habit.name} ${_translationService.translate(HabitTranslationKeys.detailsHint)}',
       hint: _translationService.translate(HabitTranslationKeys.openDetailsHint),
-      child: Material(
-        color: AppTheme.surface1,
-        borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
-        child: InkWell(
-          onTap: widget.onOpenDetails,
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppTheme.surface1,
           borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
-          child: Padding(
-            padding: EdgeInsets.only(
-              left: (widget.style == HabitListStyle.grid)
-                  ? AppTheme.sizeMedium
-                  : (isCompactView || isMobileCalendar
-                      ? HabitUiConstants.calendarPaddingMobile
-                      : HabitUiConstants.calendarPaddingDesktop),
-              right: isCompactView || isMobileCalendar
-                  ? HabitUiConstants.calendarPaddingMobile
-                  : (widget.style == HabitListStyle.calendar ? HabitUiConstants.calendarPaddingDesktop : 0),
-              // Add vertical padding to ensure content doesn't touch edges if height is small
-              top: widget.isDense ? AppTheme.sizeXSmall : AppTheme.sizeSmall,
-              bottom: widget.isDense ? AppTheme.sizeXSmall : AppTheme.sizeSmall,
-            ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Expanded(
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: HabitCardHeader(
-                      habit: widget.habit,
-                      isDense: widget.isDense,
-                      style: widget.style,
-                      translationService: _translationService,
+        ),
+        child: Material(
+          color: Colors.transparent,
+          borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
+          child: InkWell(
+            onTap: widget.onOpenDetails,
+            borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: (widget.style == HabitListStyle.grid)
+                    ? AppTheme.sizeMedium
+                    : (isCompactView || isMobileCalendar
+                        ? HabitUiConstants.calendarPaddingMobile
+                        : HabitUiConstants.calendarPaddingDesktop),
+                right: isCompactView || isMobileCalendar
+                    ? HabitUiConstants.calendarPaddingMobile
+                    : (widget.style == HabitListStyle.calendar ? HabitUiConstants.calendarPaddingDesktop : 0),
+                // Add vertical padding to ensure content doesn't touch edges if height is small
+                top: widget.isDense ? AppTheme.sizeXSmall : AppTheme.sizeSmall,
+                bottom: widget.isDense ? AppTheme.sizeXSmall : AppTheme.sizeSmall,
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: HabitCardHeader(
+                        habit: widget.habit,
+                        isDense: widget.isDense,
+                        style: widget.style,
+                        translationService: _translationService,
+                      ),
                     ),
                   ),
-                ),
-                if (_buildTrailing(isCompactView) != null) ...[
-                  const SizedBox(width: AppTheme.sizeSmall),
-                  _buildTrailing(isCompactView)!,
+                  if (_buildTrailing(isCompactView) != null) ...[
+                    const SizedBox(width: AppTheme.sizeSmall),
+                    _buildTrailing(isCompactView)!,
+                  ],
                 ],
-              ],
+              ),
             ),
           ),
         ),
@@ -260,32 +266,38 @@ class _HabitCardState extends State<HabitCard> {
         button: true,
         label: '${widget.habit.name} ${_translationService.translate(HabitTranslationKeys.detailsHint)}',
         hint: _translationService.translate(HabitTranslationKeys.openDetailsHint),
-        child: Material(
-          color: AppTheme.surface1,
-          borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
-          child: InkWell(
-            onTap: widget.onOpenDetails,
+        child: Container(
+          decoration: BoxDecoration(
+            color: AppTheme.surface1,
             borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
-            child: Padding(
-              padding: EdgeInsets.only(
-                left: AppTheme.sizeMedium,
-                right: isCompactView ? AppTheme.sizeSmall : 0,
-                top: AppTheme.sizeSmall,
-                bottom: AppTheme.sizeSmall,
-              ),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Expanded(
-                    child: HabitCardHeader(
-                        habit: widget.habit,
-                        isDense: widget.isDense,
-                        style: widget.style,
-                        translationService: _translationService),
-                  ),
-                  const SizedBox(width: AppTheme.sizeSmall),
-                  _buildTrailingForList()!,
-                ],
+          ),
+          child: Material(
+            color: Colors.transparent,
+            borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
+            child: InkWell(
+              onTap: widget.onOpenDetails,
+              borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
+              child: Padding(
+                padding: EdgeInsets.only(
+                  left: AppTheme.sizeMedium,
+                  right: isCompactView ? AppTheme.sizeSmall : 0,
+                  top: AppTheme.sizeSmall,
+                  bottom: AppTheme.sizeSmall,
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: HabitCardHeader(
+                          habit: widget.habit,
+                          isDense: widget.isDense,
+                          style: widget.style,
+                          translationService: _translationService),
+                    ),
+                    const SizedBox(width: AppTheme.sizeSmall),
+                    _buildTrailingForList()!,
+                  ],
+                ),
               ),
             ),
           ),

--- a/src/lib/presentation/ui/features/habits/components/habit_card/habit_card.dart
+++ b/src/lib/presentation/ui/features/habits/components/habit_card/habit_card.dart
@@ -215,6 +215,7 @@ class _HabitCardState extends State<HabitCard> {
         child: Material(
           color: Colors.transparent,
           borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
+          clipBehavior: Clip.antiAlias,
           child: InkWell(
             onTap: widget.onOpenDetails,
             borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
@@ -274,6 +275,7 @@ class _HabitCardState extends State<HabitCard> {
           child: Material(
             color: Colors.transparent,
             borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
+            clipBehavior: Clip.antiAlias,
             child: InkWell(
               onTap: widget.onOpenDetails,
               borderRadius: BorderRadius.circular(AppTheme.sizeMedium),

--- a/src/lib/presentation/ui/features/tasks/components/task_card.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_card.dart
@@ -77,67 +77,77 @@ class TaskCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final hasCurrentReminder = _hasReminder;
 
-    return ListTile(
-      tileColor: transparent ? Colors.transparent : AppTheme.surface1,
-      shape: RoundedRectangleBorder(
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: transparent ? Colors.transparent : AppTheme.surface1,
         borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
       ),
-      visualDensity: isDense ? VisualDensity.compact : VisualDensity.standard,
-      dense: isDense,
-      onTap: onOpenDetails,
-      leading: TaskCompleteButton(
-        taskId: taskItem.id,
-        isCompleted: taskItem.isCompleted,
-        onToggleCompleted: onCompleted,
-        color: taskItem.priority != null ? _getPriorityColor(taskItem.priority!) : null,
-        subTasksCompletionPercentage: taskItem.subTasksCompletionPercentage,
-        size: isDense ? AppTheme.iconSizeSmall : AppTheme.iconSizeMedium,
-      ),
-      title: _buildTitleAndMetadata(context),
-      subtitle: showSubTasks && taskItem.subTasks.isNotEmpty
-          ? Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: _buildSubTasks(context),
-            )
-          : null,
-      contentPadding: EdgeInsets.only(
-        left: AppTheme.sizeMedium,
-        right: isCustomOrder ? AppTheme.sizeSmall : 0,
-      ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Reminder icon
-          if (hasCurrentReminder)
-            Icon(
-              Icons.notifications,
-              size: isDense ? AppTheme.iconSizeSmall : AppTheme.iconSizeMedium,
-              color: Theme.of(context).colorScheme.primary,
-            ).wrapWithTooltip(
-              enabled: hasCurrentReminder,
-              message: _getReminderTooltip(),
-            ),
-          // Schedule button
-          if (showScheduleButton)
-            ScheduleButton(
-              translationService: _translationService,
-              onScheduleSelected: _handleSchedule,
-              isDense: isDense,
-              currentPlannedDate: taskItem.plannedDate,
-            ),
-          if (trailingButtons != null)
-            ...trailingButtons!.map((widget) {
-              if (widget is IconButton) {
-                return IconButton(
-                  icon: widget.icon,
-                  onPressed: widget.onPressed,
-                  color: widget.color,
-                  tooltip: widget.tooltip,
-                );
-              }
-              return widget;
-            }),
-        ],
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
+        child: ListTile(
+          tileColor: Colors.transparent,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
+          ),
+          visualDensity: isDense ? VisualDensity.compact : VisualDensity.standard,
+          dense: isDense,
+          onTap: onOpenDetails,
+          leading: TaskCompleteButton(
+            taskId: taskItem.id,
+            isCompleted: taskItem.isCompleted,
+            onToggleCompleted: onCompleted,
+            color: taskItem.priority != null ? _getPriorityColor(taskItem.priority!) : null,
+            subTasksCompletionPercentage: taskItem.subTasksCompletionPercentage,
+            size: isDense ? AppTheme.iconSizeSmall : AppTheme.iconSizeMedium,
+          ),
+          title: _buildTitleAndMetadata(context),
+          subtitle: showSubTasks && taskItem.subTasks.isNotEmpty
+              ? Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: _buildSubTasks(context),
+                )
+              : null,
+          contentPadding: EdgeInsets.only(
+            left: AppTheme.sizeMedium,
+            right: isCustomOrder ? AppTheme.sizeSmall : 0,
+          ),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Reminder icon
+              if (hasCurrentReminder)
+                Icon(
+                  Icons.notifications,
+                  size: isDense ? AppTheme.iconSizeSmall : AppTheme.iconSizeMedium,
+                  color: Theme.of(context).colorScheme.primary,
+                ).wrapWithTooltip(
+                  enabled: hasCurrentReminder,
+                  message: _getReminderTooltip(),
+                ),
+              // Schedule button
+              if (showScheduleButton)
+                ScheduleButton(
+                  translationService: _translationService,
+                  onScheduleSelected: _handleSchedule,
+                  isDense: isDense,
+                  currentPlannedDate: taskItem.plannedDate,
+                ),
+              if (trailingButtons != null)
+                ...trailingButtons!.map((widget) {
+                  if (widget is IconButton) {
+                    return IconButton(
+                      icon: widget.icon,
+                      onPressed: widget.onPressed,
+                      color: widget.color,
+                      tooltip: widget.tooltip,
+                    );
+                  }
+                  return widget;
+                }),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/src/lib/presentation/ui/features/tasks/components/task_card.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_card.dart
@@ -85,6 +85,7 @@ class TaskCard extends StatelessWidget {
       child: Material(
         color: Colors.transparent,
         borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
+        clipBehavior: Clip.antiAlias,
         child: ListTile(
           tileColor: Colors.transparent,
           shape: RoundedRectangleBorder(

--- a/src/lib/presentation/ui/features/tasks/components/tasks_list.dart
+++ b/src/lib/presentation/ui/features/tasks/components/tasks_list.dart
@@ -108,7 +108,6 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
   GetListTasksQueryResponse? _tasks;
   final ScrollController _scrollController = ScrollController();
   double? _savedScrollPosition;
-  final PageStorageKey _pageStorageKey = const PageStorageKey<String>('task_list_scroll');
 
   // Drag state notifier for reorderable list
   late final DragStateNotifier _dragStateNotifier;
@@ -185,8 +184,29 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
   void didUpdateWidget(TaskList oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (_isFilterChanged(oldWidget) && mounted) {
-      refresh();
+    final isLayoutChanged = oldWidget.forceOriginalLayout != widget.forceOriginalLayout;
+    final isFilterChanged = _isFilterChanged(oldWidget);
+
+    if ((isLayoutChanged || isFilterChanged) && mounted) {
+      // For ALL changes including layout and filters, force immediate rebuild to prevent visual corruption
+      setState(() {
+        // Recreate the tasks list to force complete rebuild
+        if (_tasks != null) {
+          _tasks = GetListTasksQueryResponse(
+            items: _tasks!.items,
+            totalItemCount: _tasks!.totalItemCount,
+            pageIndex: _tasks!.pageIndex,
+            pageSize: _tasks!.pageSize,
+          );
+        }
+      });
+
+      // Also trigger a data refresh to get updated filtered results
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          refresh();
+        }
+      });
     }
   }
 
@@ -445,33 +465,38 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
     final items = _getFilteredTasks();
     return items
         .map((task) => Container(
-              key: ValueKey(task.id),
+              key: ValueKey('task_${task.id}_${widget.forceOriginalLayout}'),
               child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: AppTheme.size3XSmall),
-                child: TaskCard(
-                  taskItem: task,
-                  transparent: widget.transparentCards,
-                  trailingButtons: [
-                    if (widget.trailingButtons != null) ...widget.trailingButtons!(task),
-                    if (widget.showSelectButton)
-                      IconButton(
-                        icon: const Icon(Icons.push_pin_outlined, color: Colors.grey),
-                        onPressed: () => widget.onSelectTask?.call(task),
-                      ),
-                    if (widget.enableReordering && widget.filterByCompleted != true && !widget.forceOriginalLayout)
-                      ReorderableDragStartListener(
-                        index: items.indexOf(task),
-                        child: const Icon(Icons.drag_handle, color: Colors.grey),
-                      ),
-                  ],
-                  onCompleted: _onTaskCompleted,
-                  onOpenDetails: () => widget.onClickTask(task),
-                  onScheduled: !task.isCompleted && widget.onScheduleTask != null
-                      ? () => widget.onScheduleTask!(task, DateTime.now())
-                      : null,
-                  isDense: AppThemeHelper.isScreenSmallerThan(context, AppTheme.screenMedium),
-                  isCustomOrder:
-                      widget.enableReordering && widget.filterByCompleted != true && !widget.forceOriginalLayout,
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 100),
+                  child: TaskCard(
+                    key: ValueKey(
+                        'task_card_${task.id}_${widget.forceOriginalLayout}_${widget.enableReordering}_${widget.sortConfig?.useCustomOrder}'),
+                    taskItem: task,
+                    transparent: widget.transparentCards,
+                    trailingButtons: [
+                      if (widget.trailingButtons != null) ...widget.trailingButtons!(task),
+                      if (widget.showSelectButton)
+                        IconButton(
+                          icon: const Icon(Icons.push_pin_outlined, color: Colors.grey),
+                          onPressed: () => widget.onSelectTask?.call(task),
+                        ),
+                      if (widget.enableReordering && widget.filterByCompleted != true && !widget.forceOriginalLayout)
+                        ReorderableDragStartListener(
+                          index: items.indexOf(task),
+                          child: const Icon(Icons.drag_handle, color: Colors.grey),
+                        ),
+                    ],
+                    onCompleted: _onTaskCompleted,
+                    onOpenDetails: () => widget.onClickTask(task),
+                    onScheduled: !task.isCompleted && widget.onScheduleTask != null
+                        ? () => widget.onScheduleTask!(task, DateTime.now())
+                        : null,
+                    isDense: AppThemeHelper.isScreenSmallerThan(context, AppTheme.screenMedium),
+                    isCustomOrder:
+                        widget.enableReordering && widget.filterByCompleted != true && !widget.forceOriginalLayout,
+                  ),
                 ),
               ),
             ))
@@ -547,7 +572,7 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
 
     if (widget.enableReordering && widget.filterByCompleted != true && !widget.forceOriginalLayout) {
       return ReorderableListView(
-        key: _pageStorageKey,
+        key: ValueKey('reorderable_tasks_${widget.forceOriginalLayout}_${_tasks?.items.length ?? 0}'),
         buildDefaultDragHandles: false,
         shrinkWrap: widget.useParentScroll,
         physics: widget.useParentScroll ? const NeverScrollableScrollPhysics() : const AlwaysScrollableScrollPhysics(),
@@ -560,7 +585,7 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
           ..._buildTaskCards(),
           if (_tasks!.hasNext && widget.paginationMode == PaginationMode.loadMore)
             Padding(
-              key: const ValueKey('load_more_button'),
+              key: ValueKey('load_more_button_reorderable_${widget.forceOriginalLayout}'),
               padding: const EdgeInsets.only(top: AppTheme.size2XSmall),
               child: Center(
                   child: LoadMoreButton(
@@ -569,7 +594,7 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
             ),
           if (_tasks!.hasNext && widget.paginationMode == PaginationMode.infinityScroll && isLoadingMore)
             Padding(
-              key: const ValueKey('loading_indicator'),
+              key: ValueKey('loading_indicator_reorderable_${widget.forceOriginalLayout}'),
               padding: const EdgeInsets.symmetric(vertical: AppTheme.sizeMedium),
               child: const Center(child: CircularProgressIndicator()),
             ),
@@ -583,7 +608,7 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
       final extraItemCount = (showLoadMore || showInfinityLoading) ? 1 : 0;
 
       return ListView.builder(
-        key: _pageStorageKey,
+        key: ValueKey('list_view_tasks_${widget.forceOriginalLayout}_${_tasks?.items.length ?? 0}'),
         controller: widget.paginationMode == PaginationMode.infinityScroll && !widget.useParentScroll
             ? _scrollController
             : null,
@@ -596,6 +621,7 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
           } else if (showLoadMore) {
             // Load more button
             return Padding(
+              key: ValueKey('load_more_button_list_${widget.forceOriginalLayout}'),
               padding: const EdgeInsets.only(top: AppTheme.size2XSmall),
               child: Center(
                   child: LoadMoreButton(
@@ -604,9 +630,10 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList> {
             );
           } else if (showInfinityLoading) {
             // Infinity scroll loading indicator
-            return const Padding(
+            return Padding(
+              key: ValueKey('loading_indicator_list_${widget.forceOriginalLayout}'),
               padding: EdgeInsets.symmetric(vertical: AppTheme.sizeMedium),
-              child: Center(child: CircularProgressIndicator()),
+              child: const Center(child: CircularProgressIndicator()),
             );
           }
           return const SizedBox.shrink();


### PR DESCRIPTION
## Summary

Fixes card background positioning corruption when users interact with list options in the Today page (habits and tasks sections).

## Problem

When list options changed (style toggles, filters, sorting), card backgrounds remained in old positions while other list elements updated correctly. This was caused by Flutter's `Material` widget caching mechanism incorrectly reusing widgets.

## Solution

Replace `Material` + `InkWell` pattern with `Container/DecoratedBox` + `Material(transparent)` + `InkWell`:

- **Container/DecoratedBox**: Handles background color (not subject to Material caching)
- **Material(transparent)**: Provides ripple effect support without affecting background
- **InkWell/ListTile**: Provides touch feedback as before

## Changes

- `habit_card.dart`: Use Container + Material(transparent) + InkWell
- `task_card.dart`: Use DecoratedBox + Material(transparent) + ListTile

## Testing

- ✅ `fvm flutter analyze` — No issues
- ✅ Manual testing on Today page — Confirmed working

Fixes RENDERING_CORRUPTION_001

## Summary by Sourcery

Resolve visual corruption of habit and task cards when changing filters, layout, or list options on the Today page.

Bug Fixes:
- Ensure habit and task card backgrounds and content stay in sync when list style, filters, or layout settings change.
- Prevent stale rendering by forcing immediate rebuilds and data refreshes when habits/tasks filters, styles, or layout flags change.

Enhancements:
- Use non-cached background containers/decoration with transparent Material + InkWell/ListTile for habit and task cards to preserve ripple behavior while avoiding Material caching issues.
- Stabilize habit and task list rendering by adding AnimatedSwitcher transitions and more specific ValueKeys for cards, lists, and loading controls.
- Remove shared PageStorage keys and unused GlobalKeys in favor of per-configuration keys to better isolate list instances across layout and filter changes.