### PR TITLE
feat(ui): streamline component layouts and implement centralized theme-based spacing

### DIFF
--- a/src/lib/presentation/ui/features/about/components/onboarding_dialog.dart
+++ b/src/lib/presentation/ui/features/about/components/onboarding_dialog.dart
@@ -138,7 +138,7 @@ class _OnboardingDialogState extends State<OnboardingDialog> {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
       child: const PermissionsPage(),
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
     );
   }
 

--- a/src/lib/presentation/ui/features/about/pages/about_page.dart
+++ b/src/lib/presentation/ui/features/about/pages/about_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:whph/main.dart';
 import 'package:whph/presentation/ui/features/about/components/app_about.dart';
 import 'package:whph/presentation/ui/features/about/constants/about_translation_keys.dart';
-import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
+import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 
 class AboutPage extends StatefulWidget {
   static const String route = '/about';
@@ -24,9 +24,9 @@ class _AboutPageState extends State<AboutPage> {
         elevation: 0,
         title: Text(_translationService.translate(AboutTranslationKeys.aboutTitle)),
       ),
-      body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.all(AppTheme.sizeLarge),
+      body: Padding(
+        padding: context.pageBodyPadding,
+        child: SingleChildScrollView(
           child: AppAbout(),
         ),
       ),

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_details_content.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_details_content.dart
@@ -14,7 +14,7 @@ import 'package:whph/presentation/ui/shared/components/detail_table.dart';
 import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/shared/constants/shared_translation_keys.dart';
 import 'package:whph/presentation/ui/shared/constants/shared_ui_constants.dart';
-import 'package:acore/acore.dart';
+import 'package:acore/acore.dart' hide Container;
 import 'package:whph/presentation/ui/shared/models/dropdown_option.dart';
 import 'package:whph/presentation/ui/shared/utils/app_theme_helper.dart';
 import 'package:whph/presentation/ui/shared/utils/async_error_handler.dart';

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_list.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_list.dart
@@ -290,11 +290,10 @@ class AppUsageListState extends State<AppUsageList> with PaginationMixin<AppUsag
         _appUsageList!.hasNext && widget.paginationMode == PaginationMode.infinityScroll && isLoadingMore;
     final extraItemCount = (showLoadMore || showInfinityLoading) ? 1 : 0;
 
-    return ListView.separated(
+    return ListView.builder(
       controller: _scrollController,
       physics: const AlwaysScrollableScrollPhysics(),
       itemCount: _appUsageList!.items.length + extraItemCount,
-      separatorBuilder: (context, index) => const SizedBox(height: AppTheme.size3XSmall),
       itemBuilder: (context, index) {
         if (index == _appUsageList!.items.length && showLoadMore) {
           return Padding(

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_statistics_view.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_statistics_view.dart
@@ -17,6 +17,7 @@ import 'package:whph/presentation/ui/shared/constants/setting_keys.dart';
 import 'package:whph/presentation/ui/features/app_usages/models/app_usage_statistics_settings.dart';
 import 'package:acore/acore.dart' hide Container;
 import 'package:intl/intl.dart';
+import 'package:whph/presentation/ui/shared/components/section_header.dart';
 
 class AppUsageStatisticsView extends PersistentListOptionsBase {
   final String appUsageId;
@@ -178,79 +179,69 @@ class _AppUsageStatisticsViewState extends PersistentListOptionsBaseState<AppUsa
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.only(left: AppTheme.sizeMedium),
-            child: Row(
-              children: [
-                Text(
-                  _translationService.translate(SharedTranslationKeys.statisticsLabel),
-                  style: Theme.of(context).textTheme.titleSmall,
-                ),
-                const SizedBox(width: AppTheme.sizeSmall),
-                Expanded(
-                  child: SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      children: [
-                        DateRangeFilter(
-                          dateFilterSetting: _dateFilterSetting,
-                          selectedStartDate: _dateFilterSetting != null ? _startDate : null,
-                          selectedEndDate: _dateFilterSetting != null ? _endDate : null,
-                          onDateFilterChange: (start, end) {
-                            setState(() {
-                              _startDate = start;
-                              _endDate = end;
-                              _updateComparisonDates();
-                              handleFilterChange();
-                            });
-                            _fetchStatistics();
-                          },
-                          onDateFilterSettingChange: (setting) {
-                            setState(() {
-                              _dateFilterSetting = setting;
-                              if (setting?.isQuickSelection == true) {
-                                final range = setting!.calculateCurrentDateRange();
-                                _startDate = range.startDate;
-                                _endDate = range.endDate;
-                              } else if (setting != null) {
-                                _startDate = setting.startDate;
-                                _endDate = setting.endDate;
-                              } else {
-                                _startDate = null;
-                                _endDate = null;
-                              }
-                              _updateComparisonDates();
-                              handleFilterChange();
-                            });
-                            _fetchStatistics();
-                          },
-                        ),
-                        const SizedBox(width: AppTheme.sizeSmall),
-                        IconButton(
-                          icon: Icon(Icons.compare_arrows),
-                          color: _showComparison ? Theme.of(context).colorScheme.primary : null,
-                          tooltip: _translationService.translate(SharedTranslationKeys.compareWithPreviousLabel),
-                          onPressed: () {
-                            setState(() {
-                              _showComparison = !_showComparison;
-                              _updateComparisonDates();
-                              handleFilterChange();
-                            });
-                            _fetchStatistics();
-                          },
-                        ),
-                        const SizedBox(width: AppTheme.sizeSmall),
-                        SaveButton(
-                            hasUnsavedChanges: hasUnsavedChanges,
-                            showSavedMessage: showSavedMessage,
-                            onSave: saveFilterSettings,
-                            tooltip: _translationService.translate(SharedTranslationKeys.saveListOptions)),
-                      ],
-                    ),
+          SectionHeader(
+            title: _translationService.translate(SharedTranslationKeys.statisticsLabel),
+            expandTrailing: true,
+            trailing: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  DateRangeFilter(
+                    dateFilterSetting: _dateFilterSetting,
+                    selectedStartDate: _dateFilterSetting != null ? _startDate : null,
+                    selectedEndDate: _dateFilterSetting != null ? _endDate : null,
+                    onDateFilterChange: (start, end) {
+                      setState(() {
+                        _startDate = start;
+                        _endDate = end;
+                        _updateComparisonDates();
+                        handleFilterChange();
+                      });
+                      _fetchStatistics();
+                    },
+                    onDateFilterSettingChange: (setting) {
+                      setState(() {
+                        _dateFilterSetting = setting;
+                        if (setting?.isQuickSelection == true) {
+                          final range = setting!.calculateCurrentDateRange();
+                          _startDate = range.startDate;
+                          _endDate = range.endDate;
+                        } else if (setting != null) {
+                          _startDate = setting.startDate;
+                          _endDate = setting.endDate;
+                        } else {
+                          _startDate = null;
+                          _endDate = null;
+                        }
+                        _updateComparisonDates();
+                        handleFilterChange();
+                      });
+                      _fetchStatistics();
+                    },
                   ),
-                ),
-              ],
+                  const SizedBox(width: AppTheme.sizeSmall),
+                  IconButton(
+                    icon: Icon(Icons.compare_arrows),
+                    color: _showComparison ? Theme.of(context).colorScheme.primary : null,
+                    tooltip: _translationService.translate(SharedTranslationKeys.compareWithPreviousLabel),
+                    onPressed: () {
+                      setState(() {
+                        _showComparison = !_showComparison;
+                        _updateComparisonDates();
+                        handleFilterChange();
+                      });
+                      _fetchStatistics();
+                    },
+                  ),
+                  const SizedBox(width: AppTheme.sizeSmall),
+                  SaveButton(
+                      hasUnsavedChanges: hasUnsavedChanges,
+                      showSavedMessage: showSavedMessage,
+                      onSave: saveFilterSettings,
+                      tooltip: _translationService.translate(SharedTranslationKeys.saveListOptions)),
+                ],
+              ),
             ),
           ),
           if (_isLoading)

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_statistics_view.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_statistics_view.dart
@@ -5,7 +5,6 @@ import 'package:whph/main.dart';
 import 'package:whph/presentation/ui/features/app_usages/constants/app_usage_translation_keys.dart';
 import 'package:whph/presentation/ui/features/app_usages/components/daily_usage_chart.dart';
 import 'package:whph/presentation/ui/features/app_usages/components/hourly_usage_chart.dart';
-import 'package:whph/presentation/ui/features/app_usages/components/statistics_summary_cards.dart';
 import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/shared/constants/shared_translation_keys.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
@@ -178,9 +177,82 @@ class _AppUsageStatisticsViewState extends PersistentListOptionsBaseState<AppUsa
     return SingleChildScrollView(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        spacing: AppTheme.sizeMedium,
         children: [
-          _buildHeaderRow(),
+          Padding(
+            padding: const EdgeInsets.only(left: AppTheme.sizeMedium),
+            child: Row(
+              children: [
+                Text(
+                  _translationService.translate(SharedTranslationKeys.statisticsLabel),
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                const SizedBox(width: AppTheme.sizeSmall),
+                Expanded(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [
+                        DateRangeFilter(
+                          dateFilterSetting: _dateFilterSetting,
+                          selectedStartDate: _dateFilterSetting != null ? _startDate : null,
+                          selectedEndDate: _dateFilterSetting != null ? _endDate : null,
+                          onDateFilterChange: (start, end) {
+                            setState(() {
+                              _startDate = start;
+                              _endDate = end;
+                              _updateComparisonDates();
+                              handleFilterChange();
+                            });
+                            _fetchStatistics();
+                          },
+                          onDateFilterSettingChange: (setting) {
+                            setState(() {
+                              _dateFilterSetting = setting;
+                              if (setting?.isQuickSelection == true) {
+                                final range = setting!.calculateCurrentDateRange();
+                                _startDate = range.startDate;
+                                _endDate = range.endDate;
+                              } else if (setting != null) {
+                                _startDate = setting.startDate;
+                                _endDate = setting.endDate;
+                              } else {
+                                _startDate = null;
+                                _endDate = null;
+                              }
+                              _updateComparisonDates();
+                              handleFilterChange();
+                            });
+                            _fetchStatistics();
+                          },
+                        ),
+                        const SizedBox(width: AppTheme.sizeSmall),
+                        IconButton(
+                          icon: Icon(Icons.compare_arrows),
+                          color: _showComparison ? Theme.of(context).colorScheme.primary : null,
+                          tooltip: _translationService.translate(SharedTranslationKeys.compareWithPreviousLabel),
+                          onPressed: () {
+                            setState(() {
+                              _showComparison = !_showComparison;
+                              _updateComparisonDates();
+                              handleFilterChange();
+                            });
+                            _fetchStatistics();
+                          },
+                        ),
+                        const SizedBox(width: AppTheme.sizeSmall),
+                        SaveButton(
+                            hasUnsavedChanges: hasUnsavedChanges,
+                            showSavedMessage: showSavedMessage,
+                            onSave: saveFilterSettings,
+                            tooltip: _translationService.translate(SharedTranslationKeys.saveListOptions)),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
           if (_isLoading)
             _buildLoadingState()
           else if (_errorMessage != null)
@@ -189,71 +261,13 @@ class _AppUsageStatisticsViewState extends PersistentListOptionsBaseState<AppUsa
             _buildEmptyState()
           else if (_statistics != null) ...[
             _buildSummaryCards(),
+            const SizedBox(height: AppTheme.sizeSmall),
             _buildDailyChart(),
+            const SizedBox(height: AppTheme.sizeSmall),
             _buildHourlyChart(),
           ],
         ],
       ),
-    );
-  }
-
-  Widget _buildHeaderRow() {
-    return Row(
-      children: [
-        DateRangeFilter(
-          dateFilterSetting: _dateFilterSetting,
-          selectedStartDate: _dateFilterSetting != null ? _startDate : null,
-          selectedEndDate: _dateFilterSetting != null ? _endDate : null,
-          onDateFilterChange: (start, end) {
-            setState(() {
-              _startDate = start;
-              _endDate = end;
-              _updateComparisonDates();
-              handleFilterChange();
-            });
-            _fetchStatistics();
-          },
-          onDateFilterSettingChange: (setting) {
-            setState(() {
-              _dateFilterSetting = setting;
-              if (setting?.isQuickSelection == true) {
-                final range = setting!.calculateCurrentDateRange();
-                _startDate = range.startDate;
-                _endDate = range.endDate;
-              } else if (setting != null) {
-                _startDate = setting.startDate;
-                _endDate = setting.endDate;
-              } else {
-                _startDate = null;
-                _endDate = null;
-              }
-              _updateComparisonDates();
-              handleFilterChange();
-            });
-            _fetchStatistics();
-          },
-        ),
-        const SizedBox(width: AppTheme.sizeSmall),
-        IconButton(
-          icon: Icon(Icons.compare_arrows),
-          color: _showComparison ? Theme.of(context).colorScheme.primary : null,
-          tooltip: _translationService.translate(SharedTranslationKeys.compareWithPreviousLabel),
-          onPressed: () {
-            setState(() {
-              _showComparison = !_showComparison;
-              _updateComparisonDates();
-              handleFilterChange();
-            });
-            _fetchStatistics();
-          },
-        ),
-        const SizedBox(width: AppTheme.sizeSmall),
-        SaveButton(
-            hasUnsavedChanges: hasUnsavedChanges,
-            showSavedMessage: showSavedMessage,
-            onSave: saveFilterSettings,
-            tooltip: _translationService.translate(SharedTranslationKeys.saveListOptions)),
-      ],
     );
   }
 
@@ -307,13 +321,67 @@ class _AppUsageStatisticsViewState extends PersistentListOptionsBaseState<AppUsa
         peakHour = h.hour;
       }
     }
-    return StatisticsSummaryCards(
-      totalUsage: _formatDuration(totalSeconds),
-      averageDaily: _formatDuration(avgDaily),
-      peakHour: _formatHour(peakHour),
-      totalUsageLabel: _translationService.translate(SharedTranslationKeys.totalUsageLabel),
-      averageDailyLabel: _translationService.translate(SharedTranslationKeys.averageDailyLabel),
-      peakHourLabel: _translationService.translate(SharedTranslationKeys.peakHourLabel),
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: _buildStatCard(
+                      _translationService.translate(SharedTranslationKeys.totalUsageLabel),
+                      _formatDuration(totalSeconds),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _buildStatCard(
+                      _translationService.translate(SharedTranslationKeys.averageDailyLabel),
+                      _formatDuration(avgDaily),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _buildStatCard(
+                      _translationService.translate(SharedTranslationKeys.peakHourLabel),
+                      _formatHour(peakHour),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStatCard(String label, String value) {
+    return Card(
+      color: AppTheme.surface1,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppTheme.sizeMedium, horizontal: AppTheme.sizeSmall),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                label,
+                style: AppTheme.bodySmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: AppTheme.size2XSmall),
+              Text(
+                value,
+                style: AppTheme.bodyMedium.copyWith(fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_statistics_view.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_statistics_view.dart
@@ -325,14 +325,14 @@ class _AppUsageStatisticsViewState extends PersistentListOptionsBaseState<AppUsa
                       _formatDuration(totalSeconds),
                     ),
                   ),
-                  const SizedBox(width: 8),
+                  const SizedBox(width: AppTheme.sizeSmall),
                   Expanded(
                     child: _buildStatCard(
                       _translationService.translate(SharedTranslationKeys.averageDailyLabel),
                       _formatDuration(avgDaily),
                     ),
                   ),
-                  const SizedBox(width: 8),
+                  const SizedBox(width: AppTheme.sizeSmall),
                   Expanded(
                     child: _buildStatCard(
                       _translationService.translate(SharedTranslationKeys.peakHourLabel),

--- a/src/lib/presentation/ui/features/app_usages/components/device_select_dropdown.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/device_select_dropdown.dart
@@ -152,7 +152,7 @@ class _DeviceSelectDropdownState extends State<DeviceSelectDropdown> {
 
     await ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: StatefulBuilder(
         builder: (BuildContext context, StateSetter setState) {
           final filteredDevices = _availableDevices.where((device) {

--- a/src/lib/presentation/ui/features/app_usages/pages/android_app_usage_debug_page.dart
+++ b/src/lib/presentation/ui/features/app_usages/pages/android_app_usage_debug_page.dart
@@ -7,6 +7,7 @@ import 'package:whph/core/application/features/app_usages/services/abstraction/i
 import 'package:whph/core/application/features/app_usages/services/abstraction/i_app_usage_tag_rule_repository.dart';
 import 'package:whph/core/application/features/app_usages/services/abstraction/i_app_usage_tag_repository.dart';
 import 'package:whph/core/application/features/app_usages/services/abstraction/i_app_usage_filter_service.dart';
+import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 
 /// Debug screen to test and compare app usage calculation methods.
 /// This helps identify why usage statistics are inflated compared to Digital Wellbeing.
@@ -91,7 +92,7 @@ class _AndroidAppUsageDebugPageState extends State<AndroidAppUsageDebugPage> {
         title: const Text('App Usage Debug'),
       ),
       body: Padding(
-        padding: const EdgeInsets.all(16.0),
+        padding: context.pageBodyPadding,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/src/lib/presentation/ui/features/app_usages/pages/app_usage_details_page.dart
+++ b/src/lib/presentation/ui/features/app_usages/pages/app_usage_details_page.dart
@@ -5,10 +5,7 @@ import 'package:whph/presentation/ui/features/app_usages/components/app_usage_de
 import 'package:whph/presentation/ui/features/app_usages/components/app_usage_statistics_view.dart';
 import 'package:whph/presentation/ui/features/app_usages/services/app_usages_service.dart';
 import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
-import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
-import 'package:whph/presentation/ui/shared/constants/shared_translation_keys.dart';
-import 'package:whph/presentation/ui/shared/components/section_header.dart';
 
 class AppUsageDetailsPage extends StatefulWidget {
   static const String route = '/app-usages/details';
@@ -23,7 +20,6 @@ class AppUsageDetailsPage extends StatefulWidget {
 
 class _AppUsageDetailsPageState extends State<AppUsageDetailsPage> {
   final _appUsagesService = container.resolve<AppUsagesService>();
-  final _translationService = container.resolve<ITranslationService>();
   final _themeService = container.resolve<IThemeService>();
 
   bool _hasChanges = false;
@@ -102,9 +98,9 @@ class _AppUsageDetailsPageState extends State<AppUsageDetailsPage> {
             ),
           ],
         ),
-        body: SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.all(AppTheme.sizeLarge),
+        body: Padding(
+          padding: context.pageBodyPadding,
+          child: SingleChildScrollView(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -114,16 +110,9 @@ class _AppUsageDetailsPageState extends State<AppUsageDetailsPage> {
                   onAppUsageUpdated: _onAppUsageUpdated,
                 ),
 
-                const SizedBox(height: 24),
+                const SizedBox(height: AppTheme.sizeMedium),
 
                 // App Usage Statistics Section
-                SectionHeader(
-                  title: _translationService.translate(SharedTranslationKeys.statisticsLabel),
-                  padding: EdgeInsets.zero,
-                  titleStyle: AppTheme.bodyLarge,
-                ),
-                const SizedBox(height: 16),
-
                 AppUsageStatisticsView(
                   appUsageId: widget.appUsageId,
                   onError: (error) {

--- a/src/lib/presentation/ui/features/app_usages/pages/app_usage_rules_page.dart
+++ b/src/lib/presentation/ui/features/app_usages/pages/app_usage_rules_page.dart
@@ -111,7 +111,7 @@ class _AppUsageRulesPageState extends State<AppUsageRulesPage> with SingleTicker
         ],
       ),
       body: Padding(
-        padding: const EdgeInsets.all(AppTheme.sizeLarge),
+        padding: context.pageBodyPadding,
         child: Column(
           children: [
             // Tab Selection

--- a/src/lib/presentation/ui/features/app_usages/pages/app_usage_view_page.dart
+++ b/src/lib/presentation/ui/features/app_usages/pages/app_usage_view_page.dart
@@ -185,7 +185,7 @@ class _AppUsageViewPageState extends State<AppUsageViewPage> {
     await ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
       child: const AppUsageRulesPage(),
-      size: DialogSize.large,
+      size: DialogSize.max,
     );
     setState(() {}); // Trigger rebuild to refresh list
   }

--- a/src/lib/presentation/ui/features/app_usages/pages/app_usage_view_page.dart
+++ b/src/lib/presentation/ui/features/app_usages/pages/app_usage_view_page.dart
@@ -21,6 +21,7 @@ import 'package:acore/utils/responsive_dialog_helper.dart';
 import 'package:whph/presentation/ui/features/settings/components/app_usage_permission.dart';
 import 'package:whph/presentation/ui/shared/components/tour_overlay/tour_overlay.dart';
 import 'package:whph/presentation/ui/shared/services/tour_navigation_service.dart';
+import 'package:whph/core/domain/shared/constants/demo_config.dart';
 
 class AppUsageViewPage extends StatefulWidget {
   static const String route = '/app-usages';
@@ -107,6 +108,17 @@ class _AppUsageViewPageState extends State<AppUsageViewPage> {
   }
 
   Future<void> _checkPermission() async {
+    // In demo mode, skip permission check and show mock data
+    if (DemoConfig.isDemoModeEnabled) {
+      if (mounted) {
+        setState(() {
+          _hasPermission = true;
+          _isCheckingPermission = false;
+        });
+      }
+      return;
+    }
+
     try {
       final hasPermission = await _deviceAppUsageService.checkUsageStatsPermission();
       if (mounted) {

--- a/src/lib/presentation/ui/features/calendar/pages/today_page.dart
+++ b/src/lib/presentation/ui/features/calendar/pages/today_page.dart
@@ -377,216 +377,204 @@ class _TodayPageState extends State<TodayPage> with SingleTickerProviderStateMix
 
             if (_mainListOptionSettingsLoaded) ...[
               // Habits Section
-              Padding(
+              AnimatedSize(
                 key: _habitsSectionKey,
-                padding: const EdgeInsets.symmetric(horizontal: AppTheme.sizeSmall),
-                child: AnimatedSize(
-                  duration: const Duration(milliseconds: 250),
-                  curve: Curves.easeInOut,
-                  alignment: Alignment.topCenter,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // Habits title and options
-                      SectionHeader(
-                        title: _translationService.translate(CalendarTranslationKeys.habitsTitle),
-                        padding: EdgeInsets.zero,
-                        trailing: Expanded(
-                          child: HabitListOptions(
-                            settingKeyVariantSuffix: _habitFilterOptionsSettingKeySuffix,
-                            onSettingsLoaded: _onHabitListOptionSettingsLoaded,
-                            selectedTagIds: _selectedTagFilter,
-                            showNoTagsFilter: _showNoTagsFilter,
-                            sortConfig: _habitSortConfig,
-                            forceOriginalLayout: _habitForceOriginalLayout,
-                            onTagFilterChange: (List<DropdownOption<String>> tags, bool isNoneSelected) {
-                              setState(() {
-                                _selectedTagFilter = tags.isEmpty ? null : tags.map((t) => t.value).toList();
-                                _showNoTagsFilter = isNoneSelected;
-                              });
-                            },
-                            onSortChange: _onHabitSortConfigChange,
-                            onLayoutToggleChange: _onHabitLayoutToggleChange,
-                            onHabitListStyleChange: _onHabitListStyleChange,
-                            habitListStyle: _habitListStyle,
-                            showViewStyleOption: true,
-                            showOnlyTodayStyles: true,
-                            showTagFilter: false,
-                            showArchiveFilter: false,
-                            showSortButton: true,
-                          ),
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeInOut,
+                alignment: Alignment.topCenter,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Habits title and options
+                    SectionHeader(
+                      title: _translationService.translate(CalendarTranslationKeys.habitsTitle),
+                      trailing: Expanded(
+                        child: HabitListOptions(
+                          settingKeyVariantSuffix: _habitFilterOptionsSettingKeySuffix,
+                          onSettingsLoaded: _onHabitListOptionSettingsLoaded,
+                          selectedTagIds: _selectedTagFilter,
+                          showNoTagsFilter: _showNoTagsFilter,
+                          sortConfig: _habitSortConfig,
+                          forceOriginalLayout: _habitForceOriginalLayout,
+                          onTagFilterChange: (List<DropdownOption<String>> tags, bool isNoneSelected) {
+                            setState(() {
+                              _selectedTagFilter = tags.isEmpty ? null : tags.map((t) => t.value).toList();
+                              _showNoTagsFilter = isNoneSelected;
+                            });
+                          },
+                          onSortChange: _onHabitSortConfigChange,
+                          onLayoutToggleChange: _onHabitLayoutToggleChange,
+                          onHabitListStyleChange: _onHabitListStyleChange,
+                          habitListStyle: _habitListStyle,
+                          showViewStyleOption: true,
+                          showOnlyTodayStyles: true,
+                          showTagFilter: false,
+                          showArchiveFilter: false,
+                          showSortButton: true,
                         ),
                       ),
-                      const SizedBox(height: AppTheme.sizeSmall),
+                    ),
+                    const SizedBox(height: AppTheme.sizeSmall),
 
-                      // Habits list
-                      if (_habitListOptionSettingsLoaded)
-                        HabitsList(
-                          key: ValueKey(
-                              'habits_list_${_habitListStyle}_$_remainingHabits${_selectedTagFilter?.join(',') ?? 'noTags'}${_showNoTagsFilter ? 'none' : 'some'}'),
-                          pageSize: 5,
-                          style: _habitListStyle,
-                          filterByTags: _showNoTagsFilter ? [] : _selectedTagFilter,
-                          filterNoTags: _showNoTagsFilter,
-                          // Only show habits not completed today
-                          excludeCompletedForDate: _todayStart,
-                          sortConfig: _habitSortConfig,
-                          enableReordering: _habitSortConfig.useCustomOrder,
-                          forceOriginalLayout: _habitForceOriginalLayout,
-                          onClickHabit: (habit) => _openHabitDetails(context, habit.id),
-                          onHabitCompleted: _onHabitCompleted,
-                          onListing: _onHabitsListed,
-                          onReorderComplete: () {
-                            // Refresh the habits list to ensure correct order
-                            setState(() {});
-                          },
-                          showDoneOverlayWhenEmpty: true,
-                        ),
-                    ],
-                  ),
+                    // Habits list
+                    if (_habitListOptionSettingsLoaded)
+                      HabitsList(
+                        key: ValueKey(
+                            'habits_list_${_habitListStyle}_$_remainingHabits${_selectedTagFilter?.join(',') ?? 'noTags'}${_showNoTagsFilter ? 'none' : 'some'}'),
+                        pageSize: 5,
+                        style: _habitListStyle,
+                        filterByTags: _showNoTagsFilter ? [] : _selectedTagFilter,
+                        filterNoTags: _showNoTagsFilter,
+                        // Only show habits not completed today
+                        excludeCompletedForDate: _todayStart,
+                        sortConfig: _habitSortConfig,
+                        enableReordering: _habitSortConfig.useCustomOrder,
+                        forceOriginalLayout: _habitForceOriginalLayout,
+                        onClickHabit: (habit) => _openHabitDetails(context, habit.id),
+                        onHabitCompleted: _onHabitCompleted,
+                        onListing: _onHabitsListed,
+                        onReorderComplete: () {
+                          // Refresh the habits list to ensure correct order
+                          setState(() {});
+                        },
+                        showDoneOverlayWhenEmpty: true,
+                      ),
+                  ],
                 ),
               ),
               const SizedBox(height: AppTheme.sizeMedium),
 
               // Tasks Section
-              Padding(
+              AnimatedSize(
                 key: _tasksSectionKey,
-                padding: const EdgeInsets.symmetric(horizontal: AppTheme.sizeSmall),
-                child: AnimatedSize(
-                  duration: const Duration(milliseconds: 250),
-                  curve: Curves.easeInOut,
-                  alignment: Alignment.topCenter,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // Tasks title and options
-                      SectionHeader(
-                        title: _translationService.translate(CalendarTranslationKeys.tasksTitle),
-                        padding: EdgeInsets.zero,
-                        trailing: Expanded(
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            children: [
-                              // Task filters
-                              Expanded(
-                                child: Padding(
-                                  padding: const EdgeInsets.only(left: AppTheme.sizeSmall),
-                                  child: TaskListOptions(
-                                    settingKeyVariantSuffix: _taskFilterOptionsSettingKeySuffix,
-                                    onSettingsLoaded: _onTaskListOptionSettingsLoaded,
-                                    onSearchChange: (query) {
-                                      setState(() {
-                                        _taskSearchQuery = query;
-                                      });
-                                    },
-                                    showCompletedTasks: _showCompletedTasks,
-                                    onCompletedTasksToggle: (showCompleted) {
-                                      setState(() {
-                                        _showCompletedTasks = showCompleted;
-                                      });
-                                    },
-                                    showSubTasks: _showSubTasks,
-                                    onSubTasksToggle: (showSubTasks) {
-                                      setState(() {
-                                        _showSubTasks = showSubTasks;
-                                      });
-                                    },
-                                    sortConfig: _taskSortConfig,
-                                    forceOriginalLayout: _taskForceOriginalLayout,
-                                    onSortChange: _onSortConfigChange,
-                                    onLayoutToggleChange: _onTaskLayoutToggleChange,
-                                    hasItems: true,
-                                    showDateFilter: false,
-                                    showTagFilter: false,
-                                    showSubTasksToggle: true,
-                                  ),
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeInOut,
+                alignment: Alignment.topCenter,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Tasks title and options
+                    SectionHeader(
+                      title: _translationService.translate(CalendarTranslationKeys.tasksTitle),
+                      trailing: Expanded(
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            // Task filters
+                            Expanded(
+                              child: Padding(
+                                padding: const EdgeInsets.only(left: AppTheme.sizeSmall),
+                                child: TaskListOptions(
+                                  settingKeyVariantSuffix: _taskFilterOptionsSettingKeySuffix,
+                                  onSettingsLoaded: _onTaskListOptionSettingsLoaded,
+                                  onSearchChange: (query) {
+                                    setState(() {
+                                      _taskSearchQuery = query;
+                                    });
+                                  },
+                                  showCompletedTasks: _showCompletedTasks,
+                                  onCompletedTasksToggle: (showCompleted) {
+                                    setState(() {
+                                      _showCompletedTasks = showCompleted;
+                                    });
+                                  },
+                                  showSubTasks: _showSubTasks,
+                                  onSubTasksToggle: (showSubTasks) {
+                                    setState(() {
+                                      _showSubTasks = showSubTasks;
+                                    });
+                                  },
+                                  sortConfig: _taskSortConfig,
+                                  forceOriginalLayout: _taskForceOriginalLayout,
+                                  onSortChange: _onSortConfigChange,
+                                  onLayoutToggleChange: _onTaskLayoutToggleChange,
+                                  hasItems: true,
+                                  showDateFilter: false,
+                                  showTagFilter: false,
+                                  showSubTasksToggle: true,
                                 ),
                               ),
+                            ),
 
-                              // Add button
-                              TaskAddButton(
-                                initialTagIds: _showNoTagsFilter ? [] : _selectedTagFilter,
-                                initialPlannedDate: DateTime.now(),
-                                initialTitle: _taskSearchQuery,
-                                initialCompleted: _showCompletedTasks,
-                              ),
-                            ],
-                          ),
+                            // Add button
+                            TaskAddButton(
+                              initialTagIds: _showNoTagsFilter ? [] : _selectedTagFilter,
+                              initialPlannedDate: DateTime.now(),
+                              initialTitle: _taskSearchQuery,
+                              initialCompleted: _showCompletedTasks,
+                            ),
+                          ],
                         ),
                       ),
+                    ),
 
-                      // Tasks list
-                      if (_taskListOptionSettingsLoaded)
-                        TaskList(
-                          key: ValueKey(
-                              'task_list_${_taskForceOriginalLayout}_$_remainingTasks${_selectedTagFilter?.join(',') ?? 'noTags'}${_showNoTagsFilter ? 'none' : 'some'}${_showCompletedTasks ? 'completed' : 'incomplete'}${_taskSearchQuery ?? 'nosearch'}'),
-                          filterByCompleted: _showCompletedTasks,
-                          filterByTags: _showNoTagsFilter ? [] : _selectedTagFilter,
-                          filterNoTags: _showNoTagsFilter,
-                          // Only apply date filters for incomplete tasks
-                          filterByPlannedStartDate: _showCompletedTasks ? null : DateTime(0),
-                          filterByPlannedEndDate: _showCompletedTasks ? null : _todayEnd,
-                          filterByDeadlineStartDate: _showCompletedTasks ? null : DateTime(0),
-                          filterByDeadlineEndDate: _showCompletedTasks ? null : _todayEnd,
-                          filterDateOr: true,
-                          // Filter completed tasks to only show those completed today
-                          filterByCompletedStartDate: _showCompletedTasks ? _todayStart : null,
-                          filterByCompletedEndDate: _showCompletedTasks ? _todayEnd : null,
-                          search: _taskSearchQuery,
-                          includeSubTasks: _showSubTasks,
-                          pageSize: 5,
-                          onClickTask: (task) => _openTaskDetails(context, task.id),
-                          onTaskCompleted: _onTaskCompleted,
-                          onList: _onTasksListed,
-                          enableReordering: _taskSortConfig.useCustomOrder,
-                          forceOriginalLayout: _taskForceOriginalLayout,
-                          showDoneOverlayWhenEmpty: true,
-                          sortConfig: _taskSortConfig,
-                        ),
-                    ],
-                  ),
+                    // Tasks list
+                    if (_taskListOptionSettingsLoaded)
+                      TaskList(
+                        key: ValueKey(
+                            'task_list_${_taskForceOriginalLayout}_$_remainingTasks${_selectedTagFilter?.join(',') ?? 'noTags'}${_showNoTagsFilter ? 'none' : 'some'}${_showCompletedTasks ? 'completed' : 'incomplete'}${_taskSearchQuery ?? 'nosearch'}'),
+                        filterByCompleted: _showCompletedTasks,
+                        filterByTags: _showNoTagsFilter ? [] : _selectedTagFilter,
+                        filterNoTags: _showNoTagsFilter,
+                        // Only apply date filters for incomplete tasks
+                        filterByPlannedStartDate: _showCompletedTasks ? null : DateTime(0),
+                        filterByPlannedEndDate: _showCompletedTasks ? null : _todayEnd,
+                        filterByDeadlineStartDate: _showCompletedTasks ? null : DateTime(0),
+                        filterByDeadlineEndDate: _showCompletedTasks ? null : _todayEnd,
+                        filterDateOr: true,
+                        // Filter completed tasks to only show those completed today
+                        filterByCompletedStartDate: _showCompletedTasks ? _todayStart : null,
+                        filterByCompletedEndDate: _showCompletedTasks ? _todayEnd : null,
+                        search: _taskSearchQuery,
+                        includeSubTasks: _showSubTasks,
+                        pageSize: 5,
+                        onClickTask: (task) => _openTaskDetails(context, task.id),
+                        onTaskCompleted: _onTaskCompleted,
+                        onList: _onTasksListed,
+                        enableReordering: _taskSortConfig.useCustomOrder,
+                        forceOriginalLayout: _taskForceOriginalLayout,
+                        showDoneOverlayWhenEmpty: true,
+                        sortConfig: _taskSortConfig,
+                      ),
+                  ],
                 ),
               ),
 
               const SizedBox(height: AppTheme.size2Small),
               // Times Section
-              Padding(
+              Column(
                 key: _timeChartSectionKey,
-                padding: const EdgeInsets.symmetric(horizontal: AppTheme.sizeSmall),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Times title and options
-                    SectionHeader(
-                      title: _translationService.translate(TagTranslationKeys.timeDistribution),
-                      padding: EdgeInsets.zero,
-                      trailing: Expanded(
-                        child: TagTimeChartOptions(
-                          settingKeyVariantSuffix: _timeChartOptionsSettingKeySuffix,
-                          onSettingsLoaded: _onTimeChartOptionsLoaded,
-                          selectedCategories: _selectedCategories,
-                          onCategoriesChanged: (categories) {
-                            setState(() {
-                              _selectedCategories = categories;
-                            });
-                          },
-                          showDateFilter: false,
-                        ),
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Times title and options
+                  SectionHeader(
+                    title: _translationService.translate(TagTranslationKeys.timeDistribution),
+                    trailing: Expanded(
+                      child: TagTimeChartOptions(
+                        settingKeyVariantSuffix: _timeChartOptionsSettingKeySuffix,
+                        onSettingsLoaded: _onTimeChartOptionsLoaded,
+                        selectedCategories: _selectedCategories,
+                        onCategoriesChanged: (categories) {
+                          setState(() {
+                            _selectedCategories = categories;
+                          });
+                        },
+                        showDateFilter: false,
                       ),
                     ),
+                  ),
 
-                    // Time chart
-                    if (_timeChartOptionsLoaded)
-                      Center(
-                        child: TagTimeChart(
-                          filterByTags: _selectedTagFilter,
-                          startDate: _todayStart,
-                          endDate: _tomorrowStart,
-                          selectedCategories: _selectedCategories,
-                        ),
+                  // Time chart
+                  if (_timeChartOptionsLoaded)
+                    Center(
+                      child: TagTimeChart(
+                        filterByTags: _selectedTagFilter,
+                        startDate: _todayStart,
+                        endDate: _tomorrowStart,
+                        selectedCategories: _selectedCategories,
                       ),
-                  ],
-                ),
+                    ),
+                ],
               ),
             ],
           ],

--- a/src/lib/presentation/ui/features/habits/components/habit_details_content/components/habit_records_section.dart
+++ b/src/lib/presentation/ui/features/habits/components/habit_details_content/components/habit_records_section.dart
@@ -1,24 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:whph/presentation/ui/features/habits/constants/habit_translation_keys.dart';
-import 'package:whph/presentation/ui/shared/components/section_header.dart';
 import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
 
 /// Builds the records header and daily record button for habit details.
 class HabitRecordsSection {
-  static Widget buildRecordsHeader({
-    required ITranslationService translationService,
-  }) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      child: SectionHeader(
-        title: translationService.translate(HabitTranslationKeys.recordsLabel),
-        padding: EdgeInsets.zero,
-      ),
-    );
-  }
-
   static Widget buildDailyRecordButton({
     required BuildContext context,
     required int dailyCompletionCount,

--- a/src/lib/presentation/ui/features/habits/components/habit_details_content/controllers/helpers/habit_dialog_helper.dart
+++ b/src/lib/presentation/ui/features/habits/components/habit_details_content/controllers/helpers/habit_dialog_helper.dart
@@ -108,7 +108,7 @@ class HabitDialogHelper {
 
     final result = await ResponsiveDialogHelper.showResponsiveDialog<HabitGoalResult>(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: HabitGoalDialog(
         hasGoal: habit.hasGoal,
         targetFrequency: habit.targetFrequency,

--- a/src/lib/presentation/ui/features/habits/components/habit_details_content/habit_details_content.dart
+++ b/src/lib/presentation/ui/features/habits/components/habit_details_content/habit_details_content.dart
@@ -322,11 +322,10 @@ class _HabitDetailsContentState extends State<HabitDetailsContent> {
                       ))
                   .toList(),
             ),
-            const SizedBox(height: AppTheme.size2XSmall),
+            const SizedBox(height: AppTheme.sizeMedium),
           ],
 
           // Records Section
-          HabitRecordsSection.buildRecordsHeader(translationService: translationService),
           if (_controller.habitRecords != null) ...[
             HabitCalendarView(
               currentMonth: _controller.currentMonth,

--- a/src/lib/presentation/ui/features/habits/components/habit_statistics_view.dart
+++ b/src/lib/presentation/ui/features/habits/components/habit_statistics_view.dart
@@ -186,7 +186,6 @@ class _HabitStatisticsViewState extends State<HabitStatisticsView> {
       children: [
         SectionHeader(
           title: _translationService.translate(HabitTranslationKeys.statisticsLabel),
-          padding: EdgeInsets.zero,
         ),
         const SizedBox(height: AppTheme.sizeSmall),
         if (_habit!.archivedDate != null) ...[

--- a/src/lib/presentation/ui/features/habits/pages/habit_details_page.dart
+++ b/src/lib/presentation/ui/features/habits/pages/habit_details_page.dart
@@ -5,8 +5,8 @@ import 'package:whph/presentation/ui/features/habits/components/habit_delete_but
 import 'package:whph/presentation/ui/features/habits/components/habit_details_content/habit_details_content.dart';
 import 'package:whph/presentation/ui/features/habits/components/habit_statistics_view.dart';
 import 'package:whph/presentation/ui/features/habits/services/habits_service.dart';
-import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
+import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 
 class HabitDetailsPage extends StatefulWidget {
   static const String route = '/habits/details';
@@ -80,7 +80,7 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
         ],
       ),
       body: Padding(
-        padding: const EdgeInsets.all(AppTheme.sizeLarge),
+        padding: context.pageBodyPadding,
         child: SingleChildScrollView(
           child: Column(
             children: [

--- a/src/lib/presentation/ui/features/notes/pages/note_details_page.dart
+++ b/src/lib/presentation/ui/features/notes/pages/note_details_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:whph/main.dart';
 import 'package:whph/presentation/ui/features/notes/components/note_delete_button.dart';
 import 'package:whph/presentation/ui/features/notes/components/note_details_content.dart';
-import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
+import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 
 class NoteDetailsPage extends StatefulWidget {
   static const String route = '/notes/details';
@@ -44,7 +44,7 @@ class _NoteDetailsPageState extends State<NoteDetailsPage> {
       ),
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.all(AppTheme.sizeLarge),
+          padding: context.pageBodyPadding,
           child: NoteDetailsContent(
             noteId: widget.noteId,
           ),

--- a/src/lib/presentation/ui/features/settings/components/about_tile.dart
+++ b/src/lib/presentation/ui/features/settings/components/about_tile.dart
@@ -16,7 +16,7 @@ class AboutTile extends StatelessWidget {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
       child: AboutPage(),
-      size: DialogSize.large,
+      size: DialogSize.max,
     );
   }
 

--- a/src/lib/presentation/ui/features/settings/components/advanced_settings_tile.dart
+++ b/src/lib/presentation/ui/features/settings/components/advanced_settings_tile.dart
@@ -15,7 +15,7 @@ class AdvancedSettingsTile extends StatelessWidget {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
       child: const AdvancedSettingsDialog(),
-      size: DialogSize.large,
+      size: DialogSize.max,
     );
   }
 

--- a/src/lib/presentation/ui/features/settings/components/debug_logs_settings.dart
+++ b/src/lib/presentation/ui/features/settings/components/debug_logs_settings.dart
@@ -93,7 +93,7 @@ class _DebugLogsSettingsState extends State<DebugLogsSettings> {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
       child: const DebugLogsDialog(),
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
     );
   }
 

--- a/src/lib/presentation/ui/features/settings/components/import_export_settings.dart
+++ b/src/lib/presentation/ui/features/settings/components/import_export_settings.dart
@@ -25,7 +25,7 @@ class ImportExportSettings extends StatelessWidget {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
       child: const _ImportExportActionsDialog(),
-      size: DialogSize.large,
+      size: DialogSize.max,
     );
   }
 

--- a/src/lib/presentation/ui/features/settings/components/language_settings.dart
+++ b/src/lib/presentation/ui/features/settings/components/language_settings.dart
@@ -222,11 +222,6 @@ class _LanguageDialog extends StatelessWidget {
           for (final section in _languageSections) ...[
             SectionHeader(
               title: section.title,
-              padding: const EdgeInsets.only(
-                left: AppTheme.sizeLarge,
-                top: AppTheme.sizeLarge,
-                bottom: AppTheme.sizeSmall,
-              ),
             ),
             for (final language in section.languages) _buildLanguageTile(context, language),
           ],

--- a/src/lib/presentation/ui/features/settings/components/language_settings.dart
+++ b/src/lib/presentation/ui/features/settings/components/language_settings.dart
@@ -19,7 +19,7 @@ class LanguageSettings extends StatelessWidget {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
       child: _LanguageDialog(),
-      size: DialogSize.large,
+      size: DialogSize.max,
     );
   }
 

--- a/src/lib/presentation/ui/features/settings/components/permission_card.dart
+++ b/src/lib/presentation/ui/features/settings/components/permission_card.dart
@@ -192,7 +192,7 @@ class PermissionCard extends StatelessWidget {
         onRequestPermission: onRequestPermission,
         actionButtonText: actionButtonText,
       ),
-      size: DialogSize.large,
+      size: DialogSize.max,
     );
   }
 }

--- a/src/lib/presentation/ui/features/settings/components/permission_settings.dart
+++ b/src/lib/presentation/ui/features/settings/components/permission_settings.dart
@@ -16,7 +16,7 @@ class PermissionSettings extends StatelessWidget {
   void _showPermissionsModal(BuildContext context) {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.max,
       child: const PermissionsPage(),
     );
   }

--- a/src/lib/presentation/ui/features/settings/components/sound_settings.dart
+++ b/src/lib/presentation/ui/features/settings/components/sound_settings.dart
@@ -187,7 +187,7 @@ class _SoundSettingsState extends State<SoundSettings> {
   void _showSoundModal() {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.max,
       child: _SoundDialog(
         soundEnabled: _soundEnabled,
         taskCompletionSoundEnabled: _taskCompletionSoundEnabled,

--- a/src/lib/presentation/ui/features/settings/components/sync_devices_tile.dart
+++ b/src/lib/presentation/ui/features/settings/components/sync_devices_tile.dart
@@ -16,7 +16,7 @@ class SyncDevicesTile extends StatelessWidget {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
       child: const SyncDevicesPage(),
-      size: DialogSize.large,
+      size: DialogSize.max,
     );
   }
 

--- a/src/lib/presentation/ui/features/settings/components/tasks_tile.dart
+++ b/src/lib/presentation/ui/features/settings/components/tasks_tile.dart
@@ -52,7 +52,7 @@ class TasksTile extends StatelessWidget {
               ResponsiveDialogHelper.showResponsiveDialog(
                 context: context,
                 child: const TaskPreferencesDialog(),
-                size: DialogSize.large,
+                size: DialogSize.xLarge,
               );
             },
           ),

--- a/src/lib/presentation/ui/features/settings/components/theme_settings.dart
+++ b/src/lib/presentation/ui/features/settings/components/theme_settings.dart
@@ -90,7 +90,7 @@ class _ThemeSettingsState extends State<ThemeSettings> {
 
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.max,
       isScrollable: false,
       child: _ThemeDialogWrapper(
         currentThemeMode: _themeMode,

--- a/src/lib/presentation/ui/features/settings/components/theme_settings.dart
+++ b/src/lib/presentation/ui/features/settings/components/theme_settings.dart
@@ -453,7 +453,6 @@ class _ThemeDialogState extends State<_ThemeDialog> {
               // Theme Mode Selection
               SectionHeader(
                 title: _translationService.translate(SettingsTranslationKeys.themeModeTitle),
-                padding: const EdgeInsets.only(left: AppTheme.sizeSmall, bottom: AppTheme.sizeSmall),
                 titleStyle: AppTheme.labelLarge,
               ),
               Row(
@@ -492,7 +491,6 @@ class _ThemeDialogState extends State<_ThemeDialog> {
               // Accent Color Section
               SectionHeader(
                 title: _translationService.translate(SettingsTranslationKeys.customAccentColorTitle),
-                padding: const EdgeInsets.only(left: AppTheme.sizeSmall, bottom: AppTheme.sizeSmall),
                 titleStyle: AppTheme.labelLarge,
               ),
 
@@ -597,7 +595,6 @@ class _ThemeDialogState extends State<_ThemeDialog> {
               // UI Density
               SectionHeader(
                 title: _translationService.translate(SettingsTranslationKeys.uiDensityTitle),
-                padding: const EdgeInsets.only(left: AppTheme.sizeSmall, bottom: AppTheme.sizeSmall),
                 titleStyle: AppTheme.labelLarge,
               ),
 

--- a/src/lib/presentation/ui/features/settings/pages/permissions_page.dart
+++ b/src/lib/presentation/ui/features/settings/pages/permissions_page.dart
@@ -6,8 +6,8 @@ import 'package:whph/presentation/ui/features/settings/components/exact_alarm_pe
 import 'package:whph/presentation/ui/features/settings/components/notification_permission.dart';
 import 'package:whph/presentation/ui/features/settings/components/startup_permission.dart';
 import 'package:whph/presentation/ui/features/settings/constants/settings_translation_keys.dart';
-import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
+import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 
 /// A page that displays all permission settings in one place
 class PermissionsPage extends StatefulWidget {
@@ -30,7 +30,7 @@ class _PermissionsPageState extends State<PermissionsPage> {
         title: Text(_translationService.translate(SettingsTranslationKeys.permissionsTitle)),
       ),
       body: Padding(
-        padding: const EdgeInsets.all(AppTheme.sizeLarge),
+        padding: context.pageBodyPadding,
         child: ListView(
           children: const [
             // App Usage Permission

--- a/src/lib/presentation/ui/features/settings/pages/settings_page.dart
+++ b/src/lib/presentation/ui/features/settings/pages/settings_page.dart
@@ -82,70 +82,64 @@ class _SettingsPageState extends State<SettingsPage> {
         child: Align(
           alignment: Alignment.topCenter,
           child: SingleChildScrollView(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppTheme.sizeMedium,
-                vertical: AppTheme.sizeSmall,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // General Section
-                  SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionGeneral)),
-                  const SizedBox(height: AppTheme.sizeSmall),
-                  Column(
-                    spacing: AppTheme.sizeSmall,
-                    children: [
-                      LanguageSettings(),
-                      StartupSettings(onLoaded: _onStartupLoaded),
-                      if (PlatformUtils.isMobile) PermissionSettings(),
-                    ],
-                  ),
-                  const SizedBox(height: AppTheme.sizeLarge),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // General Section
+                SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionGeneral)),
+                const SizedBox(height: AppTheme.sizeSmall),
+                Column(
+                  spacing: AppTheme.sizeSmall,
+                  children: [
+                    LanguageSettings(),
+                    StartupSettings(onLoaded: _onStartupLoaded),
+                    if (PlatformUtils.isMobile) PermissionSettings(),
+                  ],
+                ),
+                const SizedBox(height: AppTheme.sizeLarge),
 
-                  // Appearance Section
-                  SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionAppearance)),
-                  const SizedBox(height: AppTheme.sizeSmall),
-                  Column(
-                    spacing: AppTheme.sizeSmall,
-                    children: [
-                      ThemeSettings(onLoaded: _onThemeLoaded),
-                      SoundSettings(onLoaded: _onSoundLoaded),
-                    ],
-                  ),
-                  const SizedBox(height: AppTheme.sizeLarge),
+                // Appearance Section
+                SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionAppearance)),
+                const SizedBox(height: AppTheme.sizeSmall),
+                Column(
+                  spacing: AppTheme.sizeSmall,
+                  children: [
+                    ThemeSettings(onLoaded: _onThemeLoaded),
+                    SoundSettings(onLoaded: _onSoundLoaded),
+                  ],
+                ),
+                const SizedBox(height: AppTheme.sizeLarge),
 
-                  // Notifications Section
-                  SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionNotifications)),
-                  const SizedBox(height: AppTheme.sizeSmall),
-                  NotificationSettings(onLoaded: _onNotificationLoaded),
-                  const SizedBox(height: AppTheme.sizeLarge),
+                // Notifications Section
+                SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionNotifications)),
+                const SizedBox(height: AppTheme.sizeSmall),
+                NotificationSettings(onLoaded: _onNotificationLoaded),
+                const SizedBox(height: AppTheme.sizeLarge),
 
-                  // Data & Sync Section
-                  SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionDataSync)),
-                  const SizedBox(height: AppTheme.sizeSmall),
-                  Column(
-                    spacing: AppTheme.sizeSmall,
-                    children: [
-                      SyncDevicesTile(),
-                      const ImportExportSettings(),
-                    ],
-                  ),
-                  const SizedBox(height: AppTheme.sizeLarge),
+                // Data & Sync Section
+                SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionDataSync)),
+                const SizedBox(height: AppTheme.sizeSmall),
+                Column(
+                  spacing: AppTheme.sizeSmall,
+                  children: [
+                    SyncDevicesTile(),
+                    const ImportExportSettings(),
+                  ],
+                ),
+                const SizedBox(height: AppTheme.sizeLarge),
 
-                  // Advanced Section
-                  SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionAdvanced)),
-                  const SizedBox(height: AppTheme.sizeSmall),
-                  const AdvancedSettingsTile(),
-                  const SizedBox(height: AppTheme.sizeLarge),
+                // Advanced Section
+                SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionAdvanced)),
+                const SizedBox(height: AppTheme.sizeSmall),
+                const AdvancedSettingsTile(),
+                const SizedBox(height: AppTheme.sizeLarge),
 
-                  // About Section
-                  SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionAbout)),
-                  const SizedBox(height: AppTheme.sizeSmall),
-                  AboutTile(),
-                  const SizedBox(height: AppTheme.sizeXLarge),
-                ],
-              ),
+                // About Section
+                SectionHeader(title: translationService.translate(SettingsTranslationKeys.sectionAbout)),
+                const SizedBox(height: AppTheme.sizeSmall),
+                AboutTile(),
+                const SizedBox(height: AppTheme.sizeXLarge),
+              ],
             ),
           ),
         ),

--- a/src/lib/presentation/ui/features/sync/pages/add_sync_device_page/add_sync_device_page.dart
+++ b/src/lib/presentation/ui/features/sync/pages/add_sync_device_page/add_sync_device_page.dart
@@ -88,9 +88,12 @@ class _AddSyncDevicePageState extends State<AddSyncDevicePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: _buildAppBar(),
-      body: ListenableBuilder(
-        listenable: _controller,
-        builder: (context, _) => _buildBody(),
+      body: Padding(
+        padding: context.pageBodyPadding,
+        child: ListenableBuilder(
+          listenable: _controller,
+          builder: (context, _) => _buildBody(),
+        ),
       ),
     );
   }
@@ -161,9 +164,8 @@ class _AddSyncDevicePageState extends State<AddSyncDevicePage> {
   }
 
   Widget _buildHeader() {
-    return Container(
+    return SizedBox(
       width: double.infinity,
-      padding: const EdgeInsets.all(AppTheme.sizeLarge),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -187,7 +189,6 @@ class _AddSyncDevicePageState extends State<AddSyncDevicePage> {
 
   Widget _buildErrorMessage() {
     return Container(
-      margin: const EdgeInsets.symmetric(horizontal: AppTheme.sizeLarge),
       padding: const EdgeInsets.all(AppTheme.sizeMedium),
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.errorContainer,
@@ -216,40 +217,37 @@ class _AddSyncDevicePageState extends State<AddSyncDevicePage> {
 
   Widget _buildEmptyState() {
     return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(AppTheme.sizeLarge),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            StyledIcon(
-              Icons.devices_other,
-              size: 48,
-              isActive: false,
-            ),
-            const SizedBox(height: AppTheme.sizeMedium),
-            Text(
-              _translationService.translate(SyncTranslationKeys.noNearbyDevices),
-              style: Theme.of(context).textTheme.titleMedium,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppTheme.sizeSmall),
-            Text(
-              _translationService.translate(SyncTranslationKeys.noNearbyDevicesHint),
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppTheme.sizeLarge),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          StyledIcon(
+            Icons.devices_other,
+            size: 48,
+            isActive: false,
+          ),
+          const SizedBox(height: AppTheme.sizeMedium),
+          Text(
+            _translationService.translate(SyncTranslationKeys.noNearbyDevices),
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppTheme.sizeSmall),
+          Text(
+            _translationService.translate(SyncTranslationKeys.noNearbyDevicesHint),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppTheme.sizeLarge),
 
-            // Refresh Button
-            ElevatedButton.icon(
-              onPressed: _controller.startDeviceDiscovery,
-              icon: const Icon(Icons.refresh),
-              label: Text(_translationService.translate(SyncTranslationKeys.refreshScan)),
-            ),
-          ],
-        ),
+          // Refresh Button
+          ElevatedButton.icon(
+            onPressed: _controller.startDeviceDiscovery,
+            icon: const Icon(Icons.refresh),
+            label: Text(_translationService.translate(SyncTranslationKeys.refreshScan)),
+          ),
+        ],
       ),
     );
   }
@@ -277,7 +275,6 @@ class _AddSyncDevicePageState extends State<AddSyncDevicePage> {
         // Device List
         Expanded(
           child: ListView.builder(
-            padding: const EdgeInsets.symmetric(horizontal: AppTheme.sizeLarge),
             itemCount:
                 _controller.discoveredDevices.length + (!_controller.isScanning ? 1 : 0), // Add 1 for refresh button
             itemBuilder: (context, index) {

--- a/src/lib/presentation/ui/features/sync/pages/sync_devices_page/sync_devices_page.dart
+++ b/src/lib/presentation/ui/features/sync/pages/sync_devices_page/sync_devices_page.dart
@@ -290,25 +290,20 @@ class _SyncDevicesPageState extends State<SyncDevicesPage>
         title: Text(_translationService.translate(SyncTranslationKeys.pageTitle)),
         actions: _buildAppBarActions(),
       ),
-      body: CustomScrollView(
-        slivers: [
-          // Firewall permission card (desktop only)
-          SliverToBoxAdapter(
-            child: FirewallPermissionCard(
-              onPermissionChanged: _onFirewallPermissionChanged,
-            ),
-          ),
-
-          // Server Mode Toggle (Android only)
-          if (Platform.isAndroid)
+      body: Padding(
+        padding: context.pageBodyPadding,
+        child: CustomScrollView(
+          slivers: [
+            // Firewall permission card (desktop only)
             SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  AppTheme.sizeLarge,
-                  AppTheme.sizeLarge,
-                  AppTheme.sizeLarge,
-                  0,
-                ),
+              child: FirewallPermissionCard(
+                onPermissionChanged: _onFirewallPermissionChanged,
+              ),
+            ),
+
+            // Server Mode Toggle (Android only)
+            if (Platform.isAndroid)
+              SliverToBoxAdapter(
                 child: ServerModeToggle(
                   isServerMode: isServerMode,
                   onToggle: toggleServerMode,
@@ -318,22 +313,19 @@ class _SyncDevicesPageState extends State<SyncDevicesPage>
                       : _translationService.translate(SyncTranslationKeys.serverModeInactive),
                 ),
               ),
-            ),
 
-          // Device List
-          if (_list == null || _list!.items.isEmpty)
-            SliverFillRemaining(
-              child: SyncDevicesEmptyState(
-                message: _translationService.translate(SyncTranslationKeys.noDevicesFound),
-                addDeviceLabel: _translationService.translate(SyncTranslationKeys.addDeviceTooltip),
-                showAddButton: !isServerMode,
-                onAddDevice: _showAddDevicePage,
-              ),
-            )
-          else
-            SliverPadding(
-              padding: const EdgeInsets.all(AppTheme.sizeLarge),
-              sliver: SliverList(
+            // Device List
+            if (_list == null || _list!.items.isEmpty)
+              SliverFillRemaining(
+                child: SyncDevicesEmptyState(
+                  message: _translationService.translate(SyncTranslationKeys.noDevicesFound),
+                  addDeviceLabel: _translationService.translate(SyncTranslationKeys.addDeviceTooltip),
+                  showAddButton: !isServerMode,
+                  onAddDevice: _showAddDevicePage,
+                ),
+              )
+            else
+              SliverList(
                 delegate: SliverChildBuilderDelegate(
                   (context, index) {
                     return Padding(
@@ -350,8 +342,8 @@ class _SyncDevicesPageState extends State<SyncDevicesPage>
                   childCount: _list!.items.length,
                 ),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/src/lib/presentation/ui/features/sync/pages/sync_devices_page/sync_devices_page.dart
+++ b/src/lib/presentation/ui/features/sync/pages/sync_devices_page/sync_devices_page.dart
@@ -242,7 +242,7 @@ class _SyncDevicesPageState extends State<SyncDevicesPage>
   Future<void> _showAddDevicePage() async {
     final result = await ResponsiveDialogHelper.showResponsiveDialog<bool>(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.max,
       child: AddSyncDevicePage(
         onDeviceAdded: () {
           Logger.info('Device added from AddSyncDevicePage - refreshing device list');

--- a/src/lib/presentation/ui/features/tags/components/tag_card.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_card.dart
@@ -34,52 +34,48 @@ class _TagCardState extends State<TagCard> {
   Widget build(BuildContext context) {
     final spacing = widget.isDense ? AppTheme.size2XSmall : AppTheme.sizeSmall;
 
-    return Container(
-      constraints: const BoxConstraints(minHeight: 48),
-      alignment: Alignment.center,
-      child: ListTile(
-        tileColor: widget.transparent ? Colors.transparent : AppTheme.surface1,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
-        ),
-        visualDensity: widget.isDense ? VisualDensity.compact : VisualDensity.standard,
-        contentPadding: const EdgeInsets.only(left: AppTheme.sizeMedium, right: 0),
-        minTileHeight: 48,
-        dense: widget.isDense,
-        onTap: widget.onOpenDetails,
-        title: Text(
-          widget.tag.name.isEmpty ? _translationService.translate(SharedTranslationKeys.untitled) : widget.tag.name,
-          style: (widget.isDense ? AppTheme.bodySmall : AppTheme.bodyMedium).copyWith(
-            fontWeight: FontWeight.bold,
-            color: AppTheme.textColor,
-          ),
-          overflow: TextOverflow.ellipsis,
-          maxLines: widget.isDense ? 1 : 2,
-        ),
-        subtitle: widget.tag.relatedTags.isNotEmpty
-            ? Padding(
-                padding: EdgeInsets.only(top: spacing),
-                child: _buildRelatedTags(),
-              )
-            : null,
-        trailing: widget.trailingButtons != null
-            ? Row(
-                mainAxisSize: MainAxisSize.min,
-                children: widget.trailingButtons!.map((btn) {
-                  if (btn is IconButton) {
-                    return IconButton(
-                      icon: btn.icon,
-                      onPressed: btn.onPressed,
-                      color: btn.color,
-                      tooltip: btn.tooltip,
-                      iconSize: widget.isDense ? AppTheme.iconSizeSmall : AppTheme.iconSizeMedium,
-                    );
-                  }
-                  return btn;
-                }).toList(),
-              )
-            : null,
+    return ListTile(
+      tileColor: widget.transparent ? Colors.transparent : AppTheme.surface1,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
       ),
+      visualDensity: widget.isDense ? VisualDensity.compact : VisualDensity.standard,
+      contentPadding: const EdgeInsets.only(left: AppTheme.sizeMedium, right: 0),
+      minTileHeight: 48,
+      dense: widget.isDense,
+      onTap: widget.onOpenDetails,
+      title: Text(
+        widget.tag.name.isEmpty ? _translationService.translate(SharedTranslationKeys.untitled) : widget.tag.name,
+        style: (widget.isDense ? AppTheme.bodySmall : AppTheme.bodyMedium).copyWith(
+          fontWeight: FontWeight.bold,
+          color: AppTheme.textColor,
+        ),
+        overflow: TextOverflow.ellipsis,
+        maxLines: widget.isDense ? 1 : 2,
+      ),
+      subtitle: widget.tag.relatedTags.isNotEmpty
+          ? Padding(
+              padding: EdgeInsets.only(top: spacing),
+              child: _buildRelatedTags(),
+            )
+          : null,
+      trailing: widget.trailingButtons != null
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: widget.trailingButtons!.map((btn) {
+                if (btn is IconButton) {
+                  return IconButton(
+                    icon: btn.icon,
+                    onPressed: btn.onPressed,
+                    color: btn.color,
+                    tooltip: btn.tooltip,
+                    iconSize: widget.isDense ? AppTheme.iconSizeSmall : AppTheme.iconSizeMedium,
+                  );
+                }
+                return btn;
+              }).toList(),
+            )
+          : null,
     );
   }
 

--- a/src/lib/presentation/ui/features/tags/components/tag_card.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_card.dart
@@ -34,47 +34,52 @@ class _TagCardState extends State<TagCard> {
   Widget build(BuildContext context) {
     final spacing = widget.isDense ? AppTheme.size2XSmall : AppTheme.sizeSmall;
 
-    return ListTile(
-      tileColor: widget.transparent ? Colors.transparent : AppTheme.surface1,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
-      ),
-      visualDensity: widget.isDense ? VisualDensity.compact : VisualDensity.standard,
-      contentPadding: EdgeInsets.only(left: AppTheme.sizeMedium, right: 0),
-      dense: widget.isDense,
-      onTap: widget.onOpenDetails,
-      title: Text(
-        widget.tag.name.isEmpty ? _translationService.translate(SharedTranslationKeys.untitled) : widget.tag.name,
-        style: (widget.isDense ? AppTheme.bodySmall : AppTheme.bodyMedium).copyWith(
-          fontWeight: FontWeight.bold,
-          color: AppTheme.textColor,
+    return Container(
+      constraints: const BoxConstraints(minHeight: 48),
+      alignment: Alignment.center,
+      child: ListTile(
+        tileColor: widget.transparent ? Colors.transparent : AppTheme.surface1,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppTheme.sizeMedium),
         ),
-        overflow: TextOverflow.ellipsis,
-        maxLines: widget.isDense ? 1 : 2,
+        visualDensity: widget.isDense ? VisualDensity.compact : VisualDensity.standard,
+        contentPadding: const EdgeInsets.only(left: AppTheme.sizeMedium, right: 0),
+        minTileHeight: 48,
+        dense: widget.isDense,
+        onTap: widget.onOpenDetails,
+        title: Text(
+          widget.tag.name.isEmpty ? _translationService.translate(SharedTranslationKeys.untitled) : widget.tag.name,
+          style: (widget.isDense ? AppTheme.bodySmall : AppTheme.bodyMedium).copyWith(
+            fontWeight: FontWeight.bold,
+            color: AppTheme.textColor,
+          ),
+          overflow: TextOverflow.ellipsis,
+          maxLines: widget.isDense ? 1 : 2,
+        ),
+        subtitle: widget.tag.relatedTags.isNotEmpty
+            ? Padding(
+                padding: EdgeInsets.only(top: spacing),
+                child: _buildRelatedTags(),
+              )
+            : null,
+        trailing: widget.trailingButtons != null
+            ? Row(
+                mainAxisSize: MainAxisSize.min,
+                children: widget.trailingButtons!.map((btn) {
+                  if (btn is IconButton) {
+                    return IconButton(
+                      icon: btn.icon,
+                      onPressed: btn.onPressed,
+                      color: btn.color,
+                      tooltip: btn.tooltip,
+                      iconSize: widget.isDense ? AppTheme.iconSizeSmall : AppTheme.iconSizeMedium,
+                    );
+                  }
+                  return btn;
+                }).toList(),
+              )
+            : null,
       ),
-      subtitle: widget.tag.relatedTags.isNotEmpty
-          ? Padding(
-              padding: EdgeInsets.only(top: spacing),
-              child: _buildRelatedTags(),
-            )
-          : null,
-      trailing: widget.trailingButtons != null
-          ? Row(
-              mainAxisSize: MainAxisSize.min,
-              children: widget.trailingButtons!.map((btn) {
-                if (btn is IconButton) {
-                  return IconButton(
-                    icon: btn.icon,
-                    onPressed: btn.onPressed,
-                    color: btn.color,
-                    tooltip: btn.tooltip,
-                    iconSize: widget.isDense ? AppTheme.iconSizeSmall : AppTheme.iconSizeMedium,
-                  );
-                }
-                return btn;
-              }).toList(),
-            )
-          : null,
     );
   }
 

--- a/src/lib/presentation/ui/features/tags/components/tag_select_dropdown.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_select_dropdown.dart
@@ -181,7 +181,7 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
   Future<void> _showTagSelectionModal(BuildContext context) async {
     final result = await ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: TagSelectDialog(
         initialSelectedTags: _selectedTags,
         excludeTagIds: widget.excludeTagIds,

--- a/src/lib/presentation/ui/features/tags/components/tag_statistics_view.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_statistics_view.dart
@@ -7,8 +7,7 @@ import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/shared/models/date_filter_setting.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
 import 'package:whph/main.dart';
-import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
-
+import 'package:whph/presentation/ui/shared/components/section_header.dart';
 import 'package:whph/presentation/ui/shared/constants/shared_translation_keys.dart';
 
 class TagStatisticsView extends StatefulWidget {
@@ -25,7 +24,6 @@ class TagStatisticsView extends StatefulWidget {
 
 class _TagStatisticsViewState extends State<TagStatisticsView> {
   final _translationService = container.resolve<ITranslationService>();
-  final _themeService = container.resolve<IThemeService>();
   final _barChartKey = GlobalKey<TagTimeBarChartState>();
 
   DateFilterSetting? _dateFilterSetting;
@@ -35,60 +33,52 @@ class _TagStatisticsViewState extends State<TagStatisticsView> {
 
   @override
   Widget build(BuildContext context) {
+    final primaryColor = Theme.of(context).colorScheme.primary;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Padding(
-          padding: const EdgeInsets.only(left: AppTheme.sizeMedium),
-          child: Row(
-            children: [
-              Text(
-                _translationService.translate(SharedTranslationKeys.statisticsLabel),
-                style: Theme.of(context).textTheme.titleSmall,
-              ),
-              const SizedBox(width: AppTheme.sizeSmall),
-              Expanded(
-                child: TagTimeChartOptions(
-                  dateFilterSetting: _dateFilterSetting,
-                  selectedStartDate: _dateFilterSetting != null ? _startDate : null,
-                  selectedEndDate: _dateFilterSetting != null ? _endDate : null,
-                  selectedCategories: _selectedCategories,
-                  onDateFilterChange: (start, end) {
-                    if (start != null && end != null) {
-                      setState(() {
-                        _startDate = start;
-                        _endDate = end;
-                        _barChartKey.currentState?.refresh();
-                      });
-                    }
-                  },
-                  onDateFilterSettingChange: (dateFilterSetting) {
-                    setState(() {
-                      _dateFilterSetting = dateFilterSetting;
-                      if (dateFilterSetting?.isQuickSelection == true) {
-                        final currentRange = dateFilterSetting!.calculateCurrentDateRange();
-                        _startDate = currentRange.startDate;
-                        _endDate = currentRange.endDate;
-                      } else if (dateFilterSetting != null) {
-                        _startDate = dateFilterSetting.startDate;
-                        _endDate = dateFilterSetting.endDate;
-                      } else {
-                        // Clear operation
-                        _startDate = null;
-                        _endDate = null;
-                      }
-                      _barChartKey.currentState?.refresh();
-                    });
-                  },
-                  onCategoriesChanged: (categories) {
-                    setState(() {
-                      _selectedCategories = categories;
-                      _barChartKey.currentState?.refresh();
-                    });
-                  },
-                ),
-              ),
-            ],
+        SectionHeader(
+          title: _translationService.translate(SharedTranslationKeys.statisticsLabel),
+          expandTrailing: true,
+          trailing: TagTimeChartOptions(
+            dateFilterSetting: _dateFilterSetting,
+            selectedStartDate: _dateFilterSetting != null ? _startDate : null,
+            selectedEndDate: _dateFilterSetting != null ? _endDate : null,
+            selectedCategories: _selectedCategories,
+            onDateFilterChange: (start, end) {
+              if (start != null && end != null) {
+                setState(() {
+                  _startDate = start;
+                  _endDate = end;
+                  _barChartKey.currentState?.refresh();
+                });
+              }
+            },
+            onDateFilterSettingChange: (dateFilterSetting) {
+              setState(() {
+                _dateFilterSetting = dateFilterSetting;
+                if (dateFilterSetting?.isQuickSelection == true) {
+                  final currentRange = dateFilterSetting!.calculateCurrentDateRange();
+                  _startDate = currentRange.startDate;
+                  _endDate = currentRange.endDate;
+                } else if (dateFilterSetting != null) {
+                  _startDate = dateFilterSetting.startDate;
+                  _endDate = dateFilterSetting.endDate;
+                } else {
+                  // Clear operation
+                  _startDate = null;
+                  _endDate = null;
+                }
+                _barChartKey.currentState?.refresh();
+              });
+            },
+            onCategoriesChanged: (categories) {
+              setState(() {
+                _selectedCategories = categories;
+                _barChartKey.currentState?.refresh();
+              });
+            },
           ),
         ),
         Card(
@@ -106,13 +96,13 @@ class _TagStatisticsViewState extends State<TagStatisticsView> {
                     Container(
                       padding: const EdgeInsets.all(AppTheme.sizeSmall),
                       decoration: BoxDecoration(
-                        color: _themeService.primaryColor.withValues(alpha: 0.15),
+                        color: primaryColor.withValues(alpha: 0.15),
                         borderRadius: BorderRadius.circular(AppTheme.sizeSmall),
                       ),
                       child: Icon(
                         Icons.bar_chart,
                         size: AppTheme.iconSizeMedium,
-                        color: _themeService.primaryColor,
+                        color: primaryColor,
                       ),
                     ),
                     const SizedBox(width: AppTheme.sizeMedium),

--- a/src/lib/presentation/ui/features/tags/components/tag_statistics_view.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_statistics_view.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:whph/core/application/features/tags/models/tag_time_category.dart';
+import 'package:whph/presentation/ui/features/tags/components/tag_time_bar_chart.dart';
+import 'package:whph/presentation/ui/features/tags/components/tag_time_chart_options.dart';
+import 'package:whph/presentation/ui/features/tags/constants/tag_translation_keys.dart';
+import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
+import 'package:whph/presentation/ui/shared/models/date_filter_setting.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
+import 'package:whph/main.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
+
+import 'package:whph/presentation/ui/shared/constants/shared_translation_keys.dart';
+
+class TagStatisticsView extends StatefulWidget {
+  final String tagId;
+
+  const TagStatisticsView({
+    super.key,
+    required this.tagId,
+  });
+
+  @override
+  State<TagStatisticsView> createState() => _TagStatisticsViewState();
+}
+
+class _TagStatisticsViewState extends State<TagStatisticsView> {
+  final _translationService = container.resolve<ITranslationService>();
+  final _themeService = container.resolve<IThemeService>();
+  final _barChartKey = GlobalKey<TagTimeBarChartState>();
+
+  DateFilterSetting? _dateFilterSetting;
+  DateTime? _startDate;
+  DateTime? _endDate;
+  Set<TagTimeCategory> _selectedCategories = {TagTimeCategory.all};
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: AppTheme.sizeMedium),
+          child: Row(
+            children: [
+              Text(
+                _translationService.translate(SharedTranslationKeys.statisticsLabel),
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              const SizedBox(width: AppTheme.sizeSmall),
+              Expanded(
+                child: TagTimeChartOptions(
+                  dateFilterSetting: _dateFilterSetting,
+                  selectedStartDate: _dateFilterSetting != null ? _startDate : null,
+                  selectedEndDate: _dateFilterSetting != null ? _endDate : null,
+                  selectedCategories: _selectedCategories,
+                  onDateFilterChange: (start, end) {
+                    if (start != null && end != null) {
+                      setState(() {
+                        _startDate = start;
+                        _endDate = end;
+                        _barChartKey.currentState?.refresh();
+                      });
+                    }
+                  },
+                  onDateFilterSettingChange: (dateFilterSetting) {
+                    setState(() {
+                      _dateFilterSetting = dateFilterSetting;
+                      if (dateFilterSetting?.isQuickSelection == true) {
+                        final currentRange = dateFilterSetting!.calculateCurrentDateRange();
+                        _startDate = currentRange.startDate;
+                        _endDate = currentRange.endDate;
+                      } else if (dateFilterSetting != null) {
+                        _startDate = dateFilterSetting.startDate;
+                        _endDate = dateFilterSetting.endDate;
+                      } else {
+                        // Clear operation
+                        _startDate = null;
+                        _endDate = null;
+                      }
+                      _barChartKey.currentState?.refresh();
+                    });
+                  },
+                  onCategoriesChanged: (categories) {
+                    setState(() {
+                      _selectedCategories = categories;
+                      _barChartKey.currentState?.refresh();
+                    });
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+        Card(
+          elevation: 1,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppTheme.containerBorderRadius),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(AppTheme.sizeLarge),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(AppTheme.sizeSmall),
+                      decoration: BoxDecoration(
+                        color: _themeService.primaryColor.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(AppTheme.sizeSmall),
+                      ),
+                      child: Icon(
+                        Icons.bar_chart,
+                        size: AppTheme.iconSizeMedium,
+                        color: _themeService.primaryColor,
+                      ),
+                    ),
+                    const SizedBox(width: AppTheme.sizeMedium),
+                    Text(
+                      _translationService.translate(TagTranslationKeys.timeRecords),
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppTheme.sizeSmall),
+                TagTimeBarChart(
+                  key: _barChartKey,
+                  filterByTags: [widget.tagId],
+                  startDate: _startDate ?? DateTime.now().subtract(const Duration(days: 30)),
+                  endDate: _endDate ?? DateTime.now(),
+                  selectedCategories: _selectedCategories,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/src/lib/presentation/ui/features/tags/components/tag_time_bar_chart.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_time_bar_chart.dart
@@ -122,6 +122,8 @@ class TagTimeBarChartState extends State<TagTimeBarChart> {
     }
 
     return ListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
       itemCount: _elementTimeData!.items.length,
       itemBuilder: (context, index) {
         final item = _elementTimeData!.items[index];
@@ -142,25 +144,22 @@ class TagTimeBarChartState extends State<TagTimeBarChart> {
       barColor = _getCategoryColor(item.category);
     }
 
-    return Padding(
-      padding: const EdgeInsets.only(bottom: AppTheme.size2XSmall),
-      child: BarChart(
-        title: item.name,
-        value: item.duration.toDouble(),
-        maxValue: maxDuration,
-        barColor: barColor,
-        formatValue: (value) => SharedUiConstants.formatDurationHuman((value / 60).toInt(), _translationService),
-        onTap: () => _openElementDetails(item),
-        additionalWidget: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              TagUiConstants.getTagTimeCategoryIcon(item.category),
-              size: AppTheme.iconSizeSmall,
-              color: Theme.of(context).colorScheme.onSurface,
-            ),
-          ],
-        ),
+    return BarChart(
+      title: item.name,
+      value: item.duration.toDouble(),
+      maxValue: maxDuration,
+      barColor: barColor,
+      formatValue: (value) => SharedUiConstants.formatDurationHuman((value / 60).toInt(), _translationService),
+      onTap: () => _openElementDetails(item),
+      additionalWidget: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            TagUiConstants.getTagTimeCategoryIcon(item.category),
+            size: AppTheme.iconSizeSmall,
+            color: Theme.of(context).colorScheme.onSurface,
+          ),
+        ],
       ),
     );
   }

--- a/src/lib/presentation/ui/features/tags/components/tag_time_bar_chart.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_time_bar_chart.dart
@@ -175,7 +175,7 @@ class TagTimeBarChartState extends State<TagTimeBarChart> {
             taskId: item.id,
             hideSidebar: true,
           ),
-          size: DialogSize.large,
+          size: DialogSize.xLarge,
         );
         break;
       case TagTimeCategory.habits:
@@ -184,7 +184,7 @@ class TagTimeBarChartState extends State<TagTimeBarChart> {
           child: HabitDetailsPage(
             habitId: item.id,
           ),
-          size: DialogSize.large,
+          size: DialogSize.xLarge,
         );
         break;
       case TagTimeCategory.appUsage:
@@ -193,7 +193,7 @@ class TagTimeBarChartState extends State<TagTimeBarChart> {
           child: AppUsageDetailsPage(
             appUsageId: item.id,
           ),
-          size: DialogSize.large,
+          size: DialogSize.xLarge,
         );
         break;
       default:

--- a/src/lib/presentation/ui/features/tags/pages/tag_details_page.dart
+++ b/src/lib/presentation/ui/features/tags/pages/tag_details_page.dart
@@ -1,33 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:whph/core/application/features/tags/models/tag_time_category.dart';
 import 'package:whph/main.dart';
-import 'package:whph/presentation/ui/features/notes/components/note_add_button.dart';
-import 'package:whph/presentation/ui/features/notes/components/note_list_options.dart';
-import 'package:whph/presentation/ui/features/notes/components/notes_list.dart';
-import 'package:whph/presentation/ui/features/notes/constants/note_translation_keys.dart';
-import 'package:whph/presentation/ui/features/notes/pages/note_details_page.dart';
-import 'package:whph/presentation/ui/features/tags/services/tags_service.dart';
-import 'package:acore/utils/dialog_size.dart';
-import 'package:whph/presentation/ui/shared/models/sort_config.dart';
-import 'package:whph/presentation/ui/features/tasks/components/task_add_button.dart';
-import 'package:whph/presentation/ui/features/tasks/components/task_list_options.dart';
-import 'package:whph/presentation/ui/features/tasks/components/tasks_list.dart';
-import 'package:whph/presentation/ui/features/tasks/pages/task_details_page.dart';
 import 'package:whph/presentation/ui/features/tags/components/tag_archive_button.dart';
 import 'package:whph/presentation/ui/features/tags/components/tag_delete_button.dart';
 import 'package:whph/presentation/ui/features/tags/components/tag_details_content.dart';
-import 'package:whph/presentation/ui/features/tags/components/tag_time_bar_chart.dart';
-import 'package:whph/presentation/ui/features/tags/components/tag_time_chart_options.dart';
 import 'package:whph/presentation/ui/features/tags/constants/tag_translation_keys.dart';
 import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
-import 'package:acore/utils/responsive_dialog_helper.dart';
-import 'package:whph/core/application/features/notes/queries/get_list_notes_query.dart';
-import 'package:whph/core/application/features/tasks/queries/get_list_tasks_query.dart';
-import 'package:whph/presentation/ui/features/tasks/constants/task_defaults.dart';
-import 'package:whph/presentation/ui/shared/models/date_filter_setting.dart';
-import 'package:whph/presentation/ui/shared/components/custom_tab_bar.dart';
+import 'package:whph/presentation/ui/features/tags/services/tags_service.dart';
+import 'package:whph/presentation/ui/features/tags/components/tag_statistics_view.dart';
 
 class TagDetailsPage extends StatefulWidget {
   static const String route = '/tags/details';
@@ -39,67 +20,26 @@ class TagDetailsPage extends StatefulWidget {
   State<TagDetailsPage> createState() => _TagDetailsPageState();
 }
 
-class _TagDetailsPageState extends State<TagDetailsPage>
-    with AutomaticKeepAliveClientMixin, SingleTickerProviderStateMixin {
+class _TagDetailsPageState extends State<TagDetailsPage> {
   final _translationService = container.resolve<ITranslationService>();
   final _themeService = container.resolve<IThemeService>();
-
-  // Note list options state
-  bool _isNoteListVisible = false;
-  String? _noteSearchQuery;
-  SortConfig<NoteSortFields>? _sortConfig;
-
-  // Task list options state
-  String? _taskSearchQuery;
-  bool _showCompletedTasks = false;
-  bool _showSubTasks = false;
-  SortConfig<TaskSortFields> _taskSortConfig = TaskDefaults.sorting;
-
-  final _barChartKey = GlobalKey<TagTimeBarChartState>();
-  DateFilterSetting? _dateFilterSetting;
-  DateTime? _startDate;
-  DateTime? _endDate;
-  Set<TagTimeCategory> _selectedCategories = {TagTimeCategory.all};
-
-  static const String _listOptionSettingKey = 'TAG_DETAILS_PAGE';
-  late TabController _tabController;
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
-    _tabController.addListener(() {
-      setState(() {});
-    });
   }
 
   @override
   void dispose() {
-    _tabController.dispose();
     super.dispose();
   }
-
-  @override
-  bool get wantKeepAlive => true;
 
   void _goBack() {
     Navigator.of(context).pop();
   }
 
-  Future<void> _openNoteDetails(String noteId) async {
-    if (!mounted) return;
-    await ResponsiveDialogHelper.showResponsiveDialog(
-      context: context,
-      child: NoteDetailsPage(noteId: noteId),
-      size: DialogSize.large,
-    );
-    setState(() {}); // Refresh the list after dialog closes
-  }
-
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
@@ -122,275 +62,26 @@ class _TagDetailsPageState extends State<TagDetailsPage>
           ),
         ],
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(AppTheme.sizeLarge),
-            child: TagDetailsContent(
-              tagId: widget.tagId,
-              onTagUpdated: () {
-                final tagsService = container.resolve<TagsService>();
-                tagsService.notifyTagUpdated(widget.tagId);
-              },
-            ),
+      body: Padding(
+        padding: context.pageBodyPadding,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TagDetailsContent(
+                tagId: widget.tagId,
+                onTagUpdated: () {
+                  final tagsService = container.resolve<TagsService>();
+                  tagsService.notifyTagUpdated(widget.tagId);
+                },
+              ),
+              const SizedBox(height: AppTheme.sizeSmall),
+              TagStatisticsView(
+                tagId: widget.tagId,
+              ),
+            ],
           ),
-          const SizedBox(height: AppTheme.sizeSmall),
-          Expanded(
-            child: Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: AppTheme.sizeLarge),
-                  child: CustomTabBar(
-                    selectedIndex: _tabController.index,
-                    onTap: (index) {
-                      setState(() {
-                        _tabController.animateTo(index);
-                      });
-                    },
-                    items: [
-                      CustomTabItem(
-                        icon: Icons.bar_chart,
-                        label: _translationService.translate(TagTranslationKeys.timeRecords),
-                      ),
-                      CustomTabItem(
-                        icon: Icons.task,
-                        label: _translationService.translate(TagTranslationKeys.detailsTasksLabel),
-                      ),
-                      CustomTabItem(
-                        icon: Icons.note_alt_outlined,
-                        label: _translationService.translate(NoteTranslationKeys.notes),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: AppTheme.sizeSmall),
-                Expanded(
-                  child: TabBarView(
-                    controller: _tabController,
-                    children: [
-                      // Time Bar Chart Tab
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: AppTheme.sizeLarge,
-                          vertical: AppTheme.sizeSmall,
-                        ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: TagTimeChartOptions(
-                                    dateFilterSetting: _dateFilterSetting,
-                                    selectedStartDate: _dateFilterSetting != null ? _startDate : null,
-                                    selectedEndDate: _dateFilterSetting != null ? _endDate : null,
-                                    selectedCategories: _selectedCategories,
-                                    onDateFilterChange: (start, end) {
-                                      if (start != null && end != null) {
-                                        setState(() {
-                                          _startDate = start;
-                                          _endDate = end;
-                                          _barChartKey.currentState?.refresh();
-                                        });
-                                      }
-                                    },
-                                    onDateFilterSettingChange: (dateFilterSetting) {
-                                      setState(() {
-                                        _dateFilterSetting = dateFilterSetting;
-                                        if (dateFilterSetting?.isQuickSelection == true) {
-                                          final currentRange = dateFilterSetting!.calculateCurrentDateRange();
-                                          _startDate = currentRange.startDate;
-                                          _endDate = currentRange.endDate;
-                                        } else if (dateFilterSetting != null) {
-                                          _startDate = dateFilterSetting.startDate;
-                                          _endDate = dateFilterSetting.endDate;
-                                        } else {
-                                          // Clear operation
-                                          _startDate = null;
-                                          _endDate = null;
-                                        }
-                                        _barChartKey.currentState?.refresh();
-                                      });
-                                    },
-                                    onCategoriesChanged: (categories) {
-                                      setState(() {
-                                        _selectedCategories = categories;
-                                        _barChartKey.currentState?.refresh();
-                                      });
-                                    },
-                                  ),
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: AppTheme.sizeSmall),
-                            Expanded(
-                              child: TagTimeBarChart(
-                                key: _barChartKey,
-                                filterByTags: [widget.tagId],
-                                startDate: _startDate ?? DateTime.now().subtract(const Duration(days: 30)),
-                                endDate: _endDate ?? DateTime.now(),
-                                selectedCategories: _selectedCategories,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-
-                      // Tasks Tab
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: AppTheme.sizeLarge,
-                          vertical: AppTheme.sizeSmall,
-                        ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: TaskListOptions(
-                                    onSearchChange: (query) {
-                                      setState(() {
-                                        _taskSearchQuery = query;
-                                      });
-                                    },
-                                    showCompletedTasks: _showCompletedTasks,
-                                    onCompletedTasksToggle: (showCompleted) {
-                                      setState(() {
-                                        _showCompletedTasks = showCompleted;
-                                      });
-                                    },
-                                    showSubTasks: _showSubTasks,
-                                    onSubTasksToggle: (showSubTasks) {
-                                      setState(() {
-                                        _showSubTasks = showSubTasks;
-                                      });
-                                    },
-                                    showDateFilter: false,
-                                    showTagFilter: false,
-                                    showSubTasksToggle: true,
-                                    hasItems: true,
-                                    sortConfig: _taskSortConfig,
-                                    onSortChange: (newConfig) {
-                                      setState(() {
-                                        _taskSortConfig = newConfig;
-                                      });
-                                    },
-                                    settingKeyVariantSuffix: _listOptionSettingKey,
-                                  ),
-                                ),
-                                if (!_showCompletedTasks) ...[
-                                  const SizedBox(width: AppTheme.sizeSmall),
-                                  TaskAddButton(
-                                    initialTagIds: [widget.tagId],
-                                    initialTitle: _taskSearchQuery,
-                                    initialCompleted: _showCompletedTasks,
-                                  ),
-                                ],
-                              ],
-                            ),
-                            const SizedBox(height: AppTheme.sizeSmall),
-                            Expanded(
-                              child: TaskList(
-                                filterByTags: [widget.tagId],
-                                filterByCompleted: _showCompletedTasks,
-                                search: _taskSearchQuery,
-                                includeSubTasks: _showSubTasks,
-                                sortConfig: _taskSortConfig,
-                                enableReordering: !_showCompletedTasks && _taskSortConfig.useCustomOrder,
-                                ignoreArchivedTagVisibility: true,
-                                useParentScroll: false,
-                                onClickTask: (task) async {
-                                  await ResponsiveDialogHelper.showResponsiveDialog(
-                                    context: context,
-                                    child: TaskDetailsPage(
-                                      taskId: task.id,
-                                      hideSidebar: true,
-                                    ),
-                                    size: DialogSize.large,
-                                  );
-                                  setState(() {}); // Refresh the list after dialog closes
-                                },
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-
-                      // Notes Tab
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: AppTheme.sizeLarge,
-                          vertical: AppTheme.sizeSmall,
-                        ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: NoteListOptions(
-                                    search: _noteSearchQuery,
-                                    sortConfig: _sortConfig,
-                                    onSearchChange: (query) {
-                                      setState(() {
-                                        _noteSearchQuery = query;
-                                      });
-                                    },
-                                    onSortChange: (sortConfig) {
-                                      setState(() {
-                                        _sortConfig = sortConfig;
-                                      });
-                                    },
-                                    showTagFilter: false,
-                                    onSettingsLoaded: () {
-                                      setState(() {
-                                        _isNoteListVisible = true;
-                                      });
-                                    },
-                                    onSaveSettings: () {
-                                      setState(() {});
-                                    },
-                                    settingKeyVariantSuffix: _listOptionSettingKey,
-                                  ),
-                                ),
-                                const SizedBox(width: AppTheme.sizeSmall),
-                                NoteAddButton(
-                                  mini: true,
-                                  initialTagIds: [widget.tagId],
-                                  initialTitle: _noteSearchQuery,
-                                  onNoteCreated: (noteId) async {
-                                    // Open note details dialog
-                                    await _openNoteDetails(noteId);
-                                    // Refresh the list after dialog closes
-                                    setState(() {});
-                                  },
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: AppTheme.sizeSmall),
-                            Expanded(
-                              child: _isNoteListVisible
-                                  ? NotesList(
-                                      filterByTags: [widget.tagId],
-                                      search: _noteSearchQuery,
-                                      sortConfig: _sortConfig,
-                                      ignoreArchivedTagVisibility: true,
-                                      onClickNote: _openNoteDetails,
-                                    )
-                                  : const SizedBox.shrink(),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/src/lib/presentation/ui/features/tags/pages/tags_page.dart
+++ b/src/lib/presentation/ui/features/tags/pages/tags_page.dart
@@ -23,6 +23,7 @@ import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service
 import 'package:whph/presentation/ui/shared/components/tour_overlay/tour_overlay.dart';
 import 'package:whph/presentation/ui/shared/services/tour_navigation_service.dart';
 import 'package:whph/presentation/ui/shared/models/date_filter_setting.dart';
+import 'package:whph/presentation/ui/shared/components/section_header.dart';
 
 class TagsPage extends StatefulWidget {
   static const String route = '/tags';
@@ -258,29 +259,19 @@ class _TagsPageState extends State<TagsPage> {
                 ),
 
                 // Tag Time Title
-                Padding(
-                  padding: const EdgeInsets.only(left: AppTheme.sizeMedium),
-                  child: Row(
-                    children: [
-                      Text(
-                        _translationService.translate(TagTranslationKeys.timeDistribution),
-                        style: Theme.of(context).textTheme.titleSmall,
-                      ),
-                      const SizedBox(width: AppTheme.sizeSmall),
-                      Expanded(
-                        child: TagTimeChartOptions(
-                          dateFilterSetting: _dateFilterSetting,
-                          selectedStartDate: _dateFilterSetting != null ? _startDate : null,
-                          selectedEndDate: _dateFilterSetting != null ? _endDate : null,
-                          onDateFilterChange: _onDateFilterChange,
-                          onDateFilterSettingChange: _onDateFilterSettingChange,
-                          selectedCategories: _selectedCategories,
-                          onCategoriesChanged: _onTimeChartCategoryChanged,
-                          settingKeyVariantSuffix: _timeChartSettingKeyVariantSuffix,
-                          onSettingsLoaded: _onTagTimeChartOptionsLoaded,
-                        ),
-                      ),
-                    ],
+                SectionHeader(
+                  title: _translationService.translate(TagTranslationKeys.timeDistribution),
+                  expandTrailing: true,
+                  trailing: TagTimeChartOptions(
+                    dateFilterSetting: _dateFilterSetting,
+                    selectedStartDate: _dateFilterSetting != null ? _startDate : null,
+                    selectedEndDate: _dateFilterSetting != null ? _endDate : null,
+                    onDateFilterChange: _onDateFilterChange,
+                    onDateFilterSettingChange: _onDateFilterSettingChange,
+                    selectedCategories: _selectedCategories,
+                    onCategoriesChanged: _onTimeChartCategoryChanged,
+                    settingKeyVariantSuffix: _timeChartSettingKeyVariantSuffix,
+                    onSettingsLoaded: _onTagTimeChartOptionsLoaded,
                   ),
                 ),
 
@@ -301,30 +292,20 @@ class _TagsPageState extends State<TagsPage> {
                   ),
 
                 // List Options
-                Padding(
-                  padding: const EdgeInsets.only(left: AppTheme.sizeMedium),
-                  child: Row(
-                    children: [
-                      Text(
-                        _translationService.translate(TagTranslationKeys.listSectionTitle),
-                        style: Theme.of(context).textTheme.titleSmall,
-                      ),
-                      const SizedBox(width: AppTheme.sizeSmall),
-                      Expanded(
-                        child: TagListOptions(
-                          onSettingsLoaded: _onListOptionLoaded,
-                          showSearchFilter: true,
-                          search: _searchFilterQuery,
-                          onSearchChange: _onListSearchChange,
-                          showSortButton: true,
-                          sortConfig: _sortConfig,
-                          onSortChange: _onListSortConfigChange,
-                          showTagFilter: false,
-                          showArchivedToggle: false,
-                          settingKeyVariantSuffix: _listSettingKeyVariantSuffix,
-                        ),
-                      ),
-                    ],
+                SectionHeader(
+                  title: _translationService.translate(TagTranslationKeys.listSectionTitle),
+                  expandTrailing: true,
+                  trailing: TagListOptions(
+                    onSettingsLoaded: _onListOptionLoaded,
+                    showSearchFilter: true,
+                    search: _searchFilterQuery,
+                    onSearchChange: _onListSearchChange,
+                    showSortButton: true,
+                    sortConfig: _sortConfig,
+                    onSortChange: _onListSortConfigChange,
+                    showTagFilter: false,
+                    showArchivedToggle: false,
+                    settingKeyVariantSuffix: _listSettingKeyVariantSuffix,
                   ),
                 ),
 

--- a/src/lib/presentation/ui/features/tags/pages/tags_page.dart
+++ b/src/lib/presentation/ui/features/tags/pages/tags_page.dart
@@ -23,7 +23,6 @@ import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service
 import 'package:whph/presentation/ui/shared/components/tour_overlay/tour_overlay.dart';
 import 'package:whph/presentation/ui/shared/services/tour_navigation_service.dart';
 import 'package:whph/presentation/ui/shared/models/date_filter_setting.dart';
-import 'package:whph/presentation/ui/shared/components/section_header.dart';
 
 class TagsPage extends StatefulWidget {
   static const String route = '/tags';
@@ -259,20 +258,29 @@ class _TagsPageState extends State<TagsPage> {
                 ),
 
                 // Tag Time Title
-                SectionHeader(
-                  key: _timeChartSectionKey,
-                  title: _translationService.translate(TagTranslationKeys.timeDistribution),
-                  padding: const EdgeInsets.symmetric(horizontal: AppTheme.sizeSmall),
-                  trailing: TagTimeChartOptions(
-                    dateFilterSetting: _dateFilterSetting,
-                    selectedStartDate: _dateFilterSetting != null ? _startDate : null,
-                    selectedEndDate: _dateFilterSetting != null ? _endDate : null,
-                    onDateFilterChange: _onDateFilterChange,
-                    onDateFilterSettingChange: _onDateFilterSettingChange,
-                    selectedCategories: _selectedCategories,
-                    onCategoriesChanged: _onTimeChartCategoryChanged,
-                    settingKeyVariantSuffix: _timeChartSettingKeyVariantSuffix,
-                    onSettingsLoaded: _onTagTimeChartOptionsLoaded,
+                Padding(
+                  padding: const EdgeInsets.only(left: AppTheme.sizeMedium),
+                  child: Row(
+                    children: [
+                      Text(
+                        _translationService.translate(TagTranslationKeys.timeDistribution),
+                        style: Theme.of(context).textTheme.titleSmall,
+                      ),
+                      const SizedBox(width: AppTheme.sizeSmall),
+                      Expanded(
+                        child: TagTimeChartOptions(
+                          dateFilterSetting: _dateFilterSetting,
+                          selectedStartDate: _dateFilterSetting != null ? _startDate : null,
+                          selectedEndDate: _dateFilterSetting != null ? _endDate : null,
+                          onDateFilterChange: _onDateFilterChange,
+                          onDateFilterSettingChange: _onDateFilterSettingChange,
+                          selectedCategories: _selectedCategories,
+                          onCategoriesChanged: _onTimeChartCategoryChanged,
+                          settingKeyVariantSuffix: _timeChartSettingKeyVariantSuffix,
+                          onSettingsLoaded: _onTagTimeChartOptionsLoaded,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
 
@@ -293,23 +301,30 @@ class _TagsPageState extends State<TagsPage> {
                   ),
 
                 // List Options
-                SectionHeader(
-                  key: _listOptionsKey,
-                  title: _translationService.translate(TagTranslationKeys.listSectionTitle),
-                  padding: const EdgeInsets.all(AppTheme.sizeSmall),
-                  trailing: Expanded(
-                    child: TagListOptions(
-                      onSettingsLoaded: _onListOptionLoaded,
-                      showSearchFilter: true,
-                      search: _searchFilterQuery,
-                      onSearchChange: _onListSearchChange,
-                      showSortButton: true,
-                      sortConfig: _sortConfig,
-                      onSortChange: _onListSortConfigChange,
-                      showTagFilter: false,
-                      showArchivedToggle: false,
-                      settingKeyVariantSuffix: _listSettingKeyVariantSuffix,
-                    ),
+                Padding(
+                  padding: const EdgeInsets.only(left: AppTheme.sizeMedium),
+                  child: Row(
+                    children: [
+                      Text(
+                        _translationService.translate(TagTranslationKeys.listSectionTitle),
+                        style: Theme.of(context).textTheme.titleSmall,
+                      ),
+                      const SizedBox(width: AppTheme.sizeSmall),
+                      Expanded(
+                        child: TagListOptions(
+                          onSettingsLoaded: _onListOptionLoaded,
+                          showSearchFilter: true,
+                          search: _searchFilterQuery,
+                          onSearchChange: _onListSearchChange,
+                          showSortButton: true,
+                          sortConfig: _sortConfig,
+                          onSortChange: _onListSortConfigChange,
+                          showTagFilter: false,
+                          showArchivedToggle: false,
+                          settingKeyVariantSuffix: _listSettingKeyVariantSuffix,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
 

--- a/src/lib/presentation/ui/features/tasks/components/priority_select_field.dart
+++ b/src/lib/presentation/ui/features/tasks/components/priority_select_field.dart
@@ -28,7 +28,7 @@ class PrioritySelectField extends StatelessWidget {
 
     await acore.ResponsiveDialogHelper.showResponsiveDialog<void>(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: StatefulBuilder(
         builder: (context, setState) {
           return PrioritySelectionDialog(

--- a/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog.dart
+++ b/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog.dart
@@ -248,7 +248,7 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
 
     await acore.ResponsiveDialogHelper.showResponsiveDialog<void>(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: StatefulBuilder(
         builder: (BuildContext context, StateSetter setDialogState) {
           return PrioritySelectionDialog(
@@ -272,7 +272,7 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
 
     await acore.ResponsiveDialogHelper.showResponsiveDialog<void>(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: StatefulBuilder(
         builder: (BuildContext context, StateSetter setDialogState) {
           return EstimatedTimeDialogContent(
@@ -299,7 +299,7 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
 
     await acore.ResponsiveDialogHelper.showResponsiveDialog<void>(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: StatefulBuilder(
         builder: (BuildContext context, StateSetter setDialogState) {
           return DescriptionDialogContent(
@@ -323,7 +323,7 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
 
     await acore.ResponsiveDialogHelper.showResponsiveDialog<void>(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: StatefulBuilder(
         builder: (BuildContext context, StateSetter setDialogState) {
           return LockSettingsDialogContent(

--- a/src/lib/presentation/ui/features/tasks/components/task_date_picker_dialog.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_date_picker_dialog.dart
@@ -41,7 +41,7 @@ class TaskDatePickerConfig {
     this.initialReminderTime,
     this.initialReminderCustomOffset,
     this.translationService,
-    this.dialogSize = DialogSize.large,
+    this.dialogSize = DialogSize.xLarge,
     this.formatType = acore.DateFormatType.dateTime,
     this.context, // Add context parameter
   });
@@ -425,7 +425,7 @@ class TaskDatePickerDialog {
     return await ResponsiveDialogHelper.showResponsiveDialog<ReminderSelectionResult>(
       context: context,
       child: child,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       isScrollable: true,
       isDismissible: true,
       enableDrag: true,

--- a/src/lib/presentation/ui/features/tasks/components/task_date_picker_field.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_date_picker_field.dart
@@ -177,7 +177,7 @@ class _TaskDatePickerFieldState extends State<TaskDatePickerField> {
           useResponsiveDesign: true,
           enableFooterActions: true,
           translationService: widget.translationService,
-          dialogSize: DialogSize.large,
+          dialogSize: DialogSize.xLarge,
           context: context,
         ),
       );

--- a/src/lib/presentation/ui/features/tasks/components/task_details_content/task_details_content.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_details_content/task_details_content.dart
@@ -240,7 +240,7 @@ class TaskDetailsContentState extends State<TaskDetailsContent> {
 
     final result = await ResponsiveDialogHelper.showResponsiveDialog<Map<String, dynamic>>(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: RecurrenceSettingsDialog(
         initialRecurrenceType: task.recurrenceType,
         initialRecurrenceInterval: task.recurrenceInterval,

--- a/src/lib/presentation/ui/features/tasks/components/timer/timer.dart
+++ b/src/lib/presentation/ui/features/tasks/components/timer/timer.dart
@@ -175,7 +175,7 @@ class _AppTimerState extends State<AppTimer> {
   Future<void> _showSettingsModal() async {
     await ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: TimerSettingsDialog(
         initialTimerMode: _controller.timerMode,
         initialWorkDuration: _controller.workDuration,

--- a/src/lib/presentation/ui/features/tasks/pages/marathon_page.dart
+++ b/src/lib/presentation/ui/features/tasks/pages/marathon_page.dart
@@ -233,7 +233,7 @@ class _MarathonPageState extends State<MarathonPage> with AutomaticKeepAliveClie
   Future<void> _showTaskDetails(String taskId) async {
     final wasDeleted = await ResponsiveDialogHelper.showResponsiveDialog<bool>(
       context: context,
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
       child: TaskDetailsPage(
         taskId: taskId,
         hideSidebar: true,

--- a/src/lib/presentation/ui/features/tasks/pages/marathon_page.dart
+++ b/src/lib/presentation/ui/features/tasks/pages/marathon_page.dart
@@ -415,9 +415,9 @@ class _MarathonPageState extends State<MarathonPage> with AutomaticKeepAliveClie
             onHover: (_) => _onUserInteraction(),
             child: Stack(
               children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
-                  child: SingleChildScrollView(
+                SingleChildScrollView(
+                  child: Padding(
+                    padding: context.pageBodyPadding,
                     child: Column(
                       key: _mainContentKey,
                       children: [

--- a/src/lib/presentation/ui/features/tasks/pages/task_details_page.dart
+++ b/src/lib/presentation/ui/features/tasks/pages/task_details_page.dart
@@ -287,7 +287,7 @@ class _TaskDetailsPageState extends State<TaskDetailsPage> with AutomaticKeepAli
         ],
       ),
       body: Padding(
-        padding: const EdgeInsets.all(AppTheme.sizeLarge),
+        padding: context.pageBodyPadding,
         child: SingleChildScrollView(
           child: Column(
             children: [
@@ -302,7 +302,6 @@ class _TaskDetailsPageState extends State<TaskDetailsPage> with AutomaticKeepAli
               // Sub Tasks Header Section
               SectionHeader(
                 title: _translationService.translate(TaskTranslationKeys.subTasksLabel),
-                padding: EdgeInsets.zero,
                 trailing: (_subTasksCompletionPercentage != null && _subTasksCompletionPercentage! > 0)
                     ? Text(
                         '${_subTasksCompletionPercentage!.toStringAsFixed(0)}%',

--- a/src/lib/presentation/ui/features/tasks/pages/task_details_page.dart
+++ b/src/lib/presentation/ui/features/tasks/pages/task_details_page.dart
@@ -172,7 +172,7 @@ class _TaskDetailsPageState extends State<TaskDetailsPage> with AutomaticKeepAli
         showCompletedTasksToggle: widget.showCompletedTasksToggle,
         onTaskDeleted: _onSubTaskDeleted,
       ),
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
     );
     // TasksList will auto-refresh, just update completion percentage
     _loadTaskDetails();

--- a/src/lib/presentation/ui/shared/components/date_range_filter/date_range_filter.dart
+++ b/src/lib/presentation/ui/shared/components/date_range_filter/date_range_filter.dart
@@ -117,7 +117,7 @@ class _DateRangeFilterState extends State<DateRangeFilter> {
       onRefreshToggleChanged: (bool enabled) {},
       actionButtonRadius: AppTheme.containerBorderRadius,
       allowNullConfirm: true,
-      dialogSize: DialogSize.large,
+      dialogSize: DialogSize.xLarge,
     );
 
     final result = await DatePickerDialog.showResponsive(

--- a/src/lib/presentation/ui/shared/components/kebab_menu.dart
+++ b/src/lib/presentation/ui/shared/components/kebab_menu.dart
@@ -67,7 +67,7 @@ class KebabMenu extends StatelessWidget {
             if (_shouldShowHelp) {
               ResponsiveDialogHelper.showResponsiveDialog<String>(
                   context: context,
-                  size: DialogSize.large,
+                  size: DialogSize.xLarge,
                   child: HelpDialog(
                     titleKey: helpTitleKey!,
                     markdownContentKey: helpMarkdownContentKey!,

--- a/src/lib/presentation/ui/shared/components/regex_help_dialog.dart
+++ b/src/lib/presentation/ui/shared/components/regex_help_dialog.dart
@@ -13,7 +13,7 @@ class RegexHelpDialog extends StatelessWidget {
     ResponsiveDialogHelper.showResponsiveDialog(
       context: context,
       child: const RegexHelpDialog(),
-      size: DialogSize.large,
+      size: DialogSize.xLarge,
     );
   }
 

--- a/src/lib/presentation/ui/shared/components/responsive_scaffold_layout.dart
+++ b/src/lib/presentation/ui/shared/components/responsive_scaffold_layout.dart
@@ -219,12 +219,7 @@ class _ResponsiveScaffoldLayoutState extends State<ResponsiveScaffoldLayout> {
             _buildDrawer(NavigationItems.topNavItems, NavigationItems.bottomNavItems),
           Expanded(
             child: Padding(
-              padding: EdgeInsets.only(
-                left: AppTheme.sizeXSmall,
-                right: AppTheme.sizeXSmall,
-                top: AppTheme.size2XSmall,
-                bottom: AppTheme.size2XSmall,
-              ),
+              padding: context.pageBodyPadding,
               child: widget.builder(context),
             ),
           ),

--- a/src/lib/presentation/ui/shared/components/section_header.dart
+++ b/src/lib/presentation/ui/shared/components/section_header.dart
@@ -9,7 +9,6 @@ import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 /// - Customizable title style
 /// - Optional trailing widget (e.g., button, switch)
 /// - Optional tap handler for interactive headers
-/// - Configurable padding
 /// - Proper accessibility support
 class SectionHeader extends StatelessWidget {
   /// The title text displayed in the header
@@ -24,9 +23,6 @@ class SectionHeader extends StatelessWidget {
   /// Optional callback when the header is tapped
   final VoidCallback? onTap;
 
-  /// Custom padding for the header. Defaults to horizontal small padding
-  final EdgeInsetsGeometry? padding;
-
   /// Custom text style for the title. Defaults to theme's titleSmall
   final TextStyle? titleStyle;
 
@@ -36,7 +32,6 @@ class SectionHeader extends StatelessWidget {
     this.icon,
     this.trailing,
     this.onTap,
-    this.padding,
     this.titleStyle,
   });
 
@@ -82,7 +77,7 @@ class SectionHeader extends StatelessWidget {
     }
 
     return Padding(
-      padding: padding ?? const EdgeInsets.symmetric(horizontal: AppTheme.sizeSmall),
+      padding: const EdgeInsets.only(left: AppTheme.sizeMedium, right: AppTheme.sizeSmall),
       child: content,
     );
   }

--- a/src/lib/presentation/ui/shared/components/section_header.dart
+++ b/src/lib/presentation/ui/shared/components/section_header.dart
@@ -26,6 +26,9 @@ class SectionHeader extends StatelessWidget {
   /// Custom text style for the title. Defaults to theme's titleSmall
   final TextStyle? titleStyle;
 
+  /// Whether the trailing widget should expand to fill the available space
+  final bool expandTrailing;
+
   const SectionHeader({
     super.key,
     required this.title,
@@ -33,6 +36,7 @@ class SectionHeader extends StatelessWidget {
     this.trailing,
     this.onTap,
     this.titleStyle,
+    this.expandTrailing = false,
   });
 
   @override
@@ -63,7 +67,7 @@ class SectionHeader extends StatelessWidget {
         ),
         if (trailing != null) ...[
           const SizedBox(width: AppTheme.sizeSmall),
-          trailing!,
+          if (expandTrailing) Expanded(child: trailing!) else trailing!,
         ],
       ],
     );

--- a/src/lib/presentation/ui/shared/components/sort_dialog_button.dart
+++ b/src/lib/presentation/ui/shared/components/sort_dialog_button.dart
@@ -59,7 +59,7 @@ class _SortDialogButtonState<T> extends State<SortDialogButton<T>> {
           translationService: _translationService,
           onClose: widget.onDialogClose,
         ),
-        size: DialogSize.large);
+        size: DialogSize.xLarge);
   }
 
   @override

--- a/src/lib/presentation/ui/shared/constants/app_theme.dart
+++ b/src/lib/presentation/ui/shared/constants/app_theme.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:whph/core/domain/shared/constants/app_theme.dart' as domain;
 import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
 import 'package:whph/main.dart';
+import 'package:whph/presentation/ui/shared/services/theme_service/page_padding_theme.dart';
 
 class AppTheme {
   static IThemeService? _themeService;
@@ -204,6 +205,25 @@ class AppTheme {
 
   // ThemeData definition (dynamic)
   static ThemeData get themeData => _service.themeData;
+}
+
+extension PagePaddingContext on BuildContext {
+  /// Retrieves the centralized page padding from the theme.
+  /// Automatically reduces horizontal padding on small screens.
+  EdgeInsets get pageBodyPadding {
+    final theme = Theme.of(this);
+    final extension = theme.extension<PagePaddingTheme>();
+
+    if (extension == null) return EdgeInsets.zero;
+
+    final isSmall = MediaQuery.sizeOf(this).width <= AppTheme.screenSmall;
+    final horizontal = isSmall ? AppTheme.sizeSmall : extension.horizontal;
+
+    return EdgeInsets.symmetric(
+      horizontal: horizontal,
+      vertical: extension.vertical,
+    );
+  }
 }
 
 /// Default theme service for tests when container is not initialized

--- a/src/lib/presentation/ui/shared/services/theme_service/page_padding_theme.dart
+++ b/src/lib/presentation/ui/shared/services/theme_service/page_padding_theme.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+/// A theme extension for controlling page-level padding consistently across the application.
+class PagePaddingTheme extends ThemeExtension<PagePaddingTheme> {
+  final double horizontal;
+  final double vertical;
+
+  const PagePaddingTheme({
+    required this.horizontal,
+    required this.vertical,
+  });
+
+  EdgeInsets get padding => EdgeInsets.symmetric(
+        horizontal: horizontal,
+        vertical: vertical,
+      );
+
+  @override
+  PagePaddingTheme copyWith({
+    double? horizontal,
+    double? vertical,
+  }) {
+    return PagePaddingTheme(
+      horizontal: horizontal ?? this.horizontal,
+      vertical: vertical ?? this.vertical,
+    );
+  }
+
+  @override
+  PagePaddingTheme lerp(ThemeExtension<PagePaddingTheme>? other, double t) {
+    if (other is! PagePaddingTheme) {
+      return this;
+    }
+    return PagePaddingTheme(
+      horizontal: lerpDouble(horizontal, other.horizontal, t) ?? horizontal,
+      vertical: lerpDouble(vertical, other.vertical, t) ?? vertical,
+    );
+  }
+
+  static double? lerpDouble(double? a, double? b, double t) {
+    if (a == null && b == null) return null;
+    a ??= 0.0;
+    b ??= 0.0;
+    return a + (b - a) * t;
+  }
+}

--- a/src/lib/presentation/ui/shared/services/theme_service/page_padding_theme.dart
+++ b/src/lib/presentation/ui/shared/services/theme_service/page_padding_theme.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 
 /// A theme extension for controlling page-level padding consistently across the application.
@@ -32,15 +33,8 @@ class PagePaddingTheme extends ThemeExtension<PagePaddingTheme> {
       return this;
     }
     return PagePaddingTheme(
-      horizontal: lerpDouble(horizontal, other.horizontal, t) ?? horizontal,
-      vertical: lerpDouble(vertical, other.vertical, t) ?? vertical,
+      horizontal: ui.lerpDouble(horizontal, other.horizontal, t) ?? horizontal,
+      vertical: ui.lerpDouble(vertical, other.vertical, t) ?? vertical,
     );
-  }
-
-  static double? lerpDouble(double? a, double? b, double t) {
-    if (a == null && b == null) return null;
-    a ??= 0.0;
-    b ??= 0.0;
-    return a + (b - a) * t;
   }
 }

--- a/src/lib/presentation/ui/shared/services/theme_service/theme_data_builder.dart
+++ b/src/lib/presentation/ui/shared/services/theme_service/theme_data_builder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:acore/acore.dart' hide Container;
 import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
+import 'package:whph/presentation/ui/shared/services/theme_service/page_padding_theme.dart';
 
 /// Builds ThemeData based on current theme settings.
 /// Extracted from ThemeService to separate theme configuration from settings management.
@@ -61,6 +62,9 @@ class ThemeDataBuilder {
       appBarTheme: _buildAppBarTheme(),
       listTileTheme: _buildListTileTheme(),
       bottomNavigationBarTheme: _buildBottomNavigationBarTheme(),
+      extensions: [
+        _buildPagePaddingTheme(),
+      ],
     );
   }
 
@@ -357,6 +361,13 @@ class ThemeDataBuilder {
       type: BottomNavigationBarType.fixed,
       showSelectedLabels: true,
       showUnselectedLabels: true,
+    );
+  }
+
+  PagePaddingTheme _buildPagePaddingTheme() {
+    return PagePaddingTheme(
+      horizontal: AppTheme.sizeSmall * densityMultiplier,
+      vertical: AppTheme.sizeSmall * densityMultiplier,
     );
   }
 }

--- a/src/test/presentation/ui/shared/components/section_header_test.dart
+++ b/src/test/presentation/ui/shared/components/section_header_test.dart
@@ -94,24 +94,6 @@ void main() {
       expect(textWidget.style?.color, equals(Colors.red));
     });
 
-    testWidgets('uses custom padding when provided', (WidgetTester tester) async {
-      const customPadding = EdgeInsets.all(24.0);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SectionHeader(
-              title: 'Test Header',
-              padding: customPadding,
-            ),
-          ),
-        ),
-      );
-
-      final paddingWidget = tester.widget<Padding>(find.byType(Padding));
-      expect(paddingWidget.padding, equals(customPadding));
-    });
-
     testWidgets('does not render icon or trailing when not provided', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(


### PR DESCRIPTION
### 🚀 Motivation and Context

Simplify complex UI structures by removing tab-based interfaces in favor of scrollable layouts. Introduce theme extension system for consistent page-level padding across the application. Consolidate inline component implementations to reduce architectural complexity while maintaining visual consistency.

### ⚙️ Implementation Details

This commit introduces a centralized theme-based spacing system and streamlines UI component layouts:

**Theme Extension System:**
- Added `PagePaddingTheme` extension to `ThemeData` for consistent page-level padding
- Implemented `theme_service` with centralized padding configuration
- Updated `app_theme.dart` with new theme extension support

**UI Layout Improvements:**
- Removed tab-based interfaces in favor of scrollable layouts
- Simplified `tag_details_page.dart` (353 → reduced lines) by extracting components
- Refactored `today_page.dart` for cleaner layout structure
- Streamlined `settings_page.dart` and component layouts

**Component Consolidation:**
- Extracted `tag_statistics_view.dart` as new shared component
- Updated `responsive_scaffold_layout.dart` for better consistency
- Standardized `section_header.dart` spacing

**Affected Areas:**
- 32 files changed with 819 insertions and 884 deletions (net code reduction)
- Features updated: app_usages, calendar, habits, notes, settings, sync, tags, tasks

### 📋 Checklist for Reviewer

- [x] Tests passed locally.
- [x] Commit history is clean and descriptive.
- [ ] Documentation updated (if applicable).
- [ ] Code quality standards were met (e.g., linter passed).

### 🔗 Related

No related issues or PRs.

## Summary by Sourcery

Introduce a centralized theme-based page padding system and streamline multiple feature pages to use consistent scrollable layouts and simplified section headers.

New Features:
- Add PagePaddingTheme extension and BuildContext helper to provide theme-driven page-level padding.
- Create TagStatisticsView as a reusable tag statistics component used by the tag details page.

Enhancements:
- Refine many feature pages (tags, app usages, habits, notes, tasks, settings, sync, about, marathon) to rely on centralized page padding instead of hard-coded paddings.
- Simplify TagDetailsPage layout by replacing tabbed content with a scrollable view that embeds shared tag statistics.
- Update tags, app usage, and statistics UIs to use inline text+options headers instead of the generic SectionHeader component in several places.
- Adjust TagTimeBarChart and app usage lists for better embedding in scrollable parents and more consistent spacing.
- Improve TagCard layout with minimum height constraints and better alignment in dense and non-dense modes.
- Simplify SectionHeader API by removing custom padding support and standardizing its internal padding.