### PR TITLE
feat(sync): add remote trigger for desktop sync via CLI --sync

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -180,6 +180,7 @@ if [[ $KOTLIN_COUNT -gt 0 ]]; then
     if [[ -n "$KTFMT_CMD" ]]; then
         print_info "🔧 Using ktfmt for Kotlin formatting..."
         # Convert relative paths to absolute
+        # shellcheck disable=SC2086  # Word splitting intentional for xargs command with args
         sed "s|^\.|$SRC_DIR|" "$KOTLIN_FILES_LIST" | xargs $KTFMT_CMD --google-style || {
             print_warning "⚠️ ktfmt formatting encountered some issues (continuing...)"
         }

--- a/scripts/validate_remote_sync.sh
+++ b/scripts/validate_remote_sync.sh
@@ -18,6 +18,7 @@ echo "Triggering sync..."
 # No, flutter run args are for flutter.
 # Effective test: Build the app.
 
+cd src/
 echo "Building Linux debug bundle (fast)..."
 fvm flutter build linux --debug
 

--- a/scripts/validate_remote_sync.sh
+++ b/scripts/validate_remote_sync.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Validation Script for Remote Sync Trigger
+
+# 1. Ensure the app is running (you must launch it manually first)
+echo "Please ensure WHPH is running separately."
+echo "If not, start it with: fvm flutter run -d linux"
+read -rp "Press Enter when app is running..."
+
+# 2. Trigger Sync
+echo "Triggering sync..."
+# Requires building the bundle or using 'flutter run' with specific target, but strict CLI args
+# usually work best with built binaries. If developing, we can try using dart run or similar if possible.
+# But for 'flutter run', arguments are passed to the tool, not the app easily unless using --dart-entrypoint-args (not standard).
+# Best way to test dev is likely to build a linux debug bundle or modify main() to print args.
+
+# Assuming we can run from source using 'flutter run' and passing args to the app?
+# No, flutter run args are for flutter.
+# Effective test: Build the app.
+
+echo "Building Linux debug bundle (fast)..."
+fvm flutter build linux --debug
+
+echo "Running trigger..."
+./build/linux/x64/debug/bundle/whph --sync
+
+echo "Done. Check the logs of the MAIN app instance."

--- a/scripts/validate_remote_sync.sh
+++ b/scripts/validate_remote_sync.sh
@@ -2,6 +2,11 @@
 
 # Validation Script for Remote Sync Trigger
 
+# Get script directory and project root for location-independent execution
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SRC_DIR="$PROJECT_ROOT/src"
+
 # 1. Ensure the app is running (you must launch it manually first)
 echo "Please ensure WHPH is running separately."
 echo "If not, start it with: fvm flutter run -d linux"
@@ -18,11 +23,11 @@ echo "Triggering sync..."
 # No, flutter run args are for flutter.
 # Effective test: Build the app.
 
-cd src/
+cd "$SRC_DIR"
 echo "Building Linux debug bundle (fast)..."
 fvm flutter build linux --debug
 
 echo "Running trigger..."
-./build/linux/x64/debug/bundle/whph --sync
+"$SRC_DIR/build/linux/x64/debug/bundle/whph" --sync
 
 echo "Done. Check the logs of the MAIN app instance."

--- a/scripts/validate_remote_sync.sh
+++ b/scripts/validate_remote_sync.sh
@@ -23,9 +23,9 @@ echo "Triggering sync..."
 # No, flutter run args are for flutter.
 # Effective test: Build the app.
 
-cd "$SRC_DIR"
+cd "$PROJECT_ROOT"
 echo "Building Linux debug bundle (fast)..."
-fvm flutter build linux --debug
+fvm flutter build linux --debug --project-directory "$SRC_DIR"
 
 echo "Running trigger..."
 "$SRC_DIR/build/linux/x64/debug/bundle/whph" --sync

--- a/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/HabitsRemoteViewsFactory.kt
+++ b/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/HabitsRemoteViewsFactory.kt
@@ -7,125 +7,126 @@ import android.util.Log
 import android.view.View
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
-import es.antonborri.home_widget.HomeWidgetBackgroundIntent
 import es.antonborri.home_widget.HomeWidgetPlugin
 import org.json.JSONObject
 
-class HabitsRemoteViewsFactory(private val context: Context) : RemoteViewsService.RemoteViewsFactory {
-    companion object {
-        private const val TAG = "HabitsRemoteViewsFactory"
-    }
-    private var habits: org.json.JSONArray? = null
+class HabitsRemoteViewsFactory(private val context: Context) :
+  RemoteViewsService.RemoteViewsFactory {
+  companion object {
+    private const val TAG = "HabitsRemoteViewsFactory"
+  }
 
-    override fun onCreate() {
-        // Data is loaded in onDataSetChanged
-    }
+  private var habits: org.json.JSONArray? = null
 
-    override fun onDataSetChanged() {
-        val widgetData = HomeWidgetPlugin.getData(context)
-        val dataString = widgetData?.getString("widget_data", null)
+  override fun onCreate() {
+    // Data is loaded in onDataSetChanged
+  }
 
-        if (dataString != null) {
-            try {
-                val data = JSONObject(dataString)
-                habits = data.optJSONArray("habits")
-            } catch (e: Exception) {
-                habits = null
-            }
-        }
-    }
+  override fun onDataSetChanged() {
+    val widgetData = HomeWidgetPlugin.getData(context)
+    val dataString = widgetData?.getString("widget_data", null)
 
-    override fun onDestroy() {
+    if (dataString != null) {
+      try {
+        val data = JSONObject(dataString)
+        habits = data.optJSONArray("habits")
+      } catch (e: Exception) {
         habits = null
+      }
     }
+  }
 
-    override fun getCount(): Int {
-        return habits?.length() ?: 0
-    }
+  override fun onDestroy() {
+    habits = null
+  }
 
-    override fun getViewAt(position: Int): RemoteViews {
-        val views = RemoteViews(context.packageName, R.layout.widget_habit_item)
+  override fun getCount(): Int {
+    return habits?.length() ?: 0
+  }
 
-        val currentHabits = habits ?: return views
-        if (position >= currentHabits.length()) return views
+  override fun getViewAt(position: Int): RemoteViews {
+    val views = RemoteViews(context.packageName, R.layout.widget_habit_item)
 
-        try {
-            val habit = currentHabits.getJSONObject(position)
-            val habitId = habit.optString("id", "")
-            val name = habit.optString("name", "Unknown habit")
-            val isCompletedToday = habit.optBoolean("isCompletedToday", false)
-            val hasGoal = habit.optBoolean("hasGoal", false)
-            val dailyTarget = habit.optInt("dailyTarget", 1)
-            val currentCompletionCount = habit.optInt("currentCompletionCount", 0)
+    val currentHabits = habits ?: return views
+    if (position >= currentHabits.length()) return views
 
-            views.setTextViewText(R.id.habit_title, name)
+    try {
+      val habit = currentHabits.getJSONObject(position)
+      val habitId = habit.optString("id", "")
+      val name = habit.optString("name", "Unknown habit")
+      val isCompletedToday = habit.optBoolean("isCompletedToday", false)
+      val hasGoal = habit.optBoolean("hasGoal", false)
+      val dailyTarget = habit.optInt("dailyTarget", 1)
+      val currentCompletionCount = habit.optInt("currentCompletionCount", 0)
 
-            // Logic copied from Provider to determine icon
-            if (hasGoal && dailyTarget > 1) {
-                when {
-                    currentCompletionCount == 0 -> {
-                        views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_check_box_outline)
-                    }
-                    currentCompletionCount < dailyTarget -> {
-                        views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_add)
-                    }
-                    currentCompletionCount >= dailyTarget -> {
-                        views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_check_box)
-                    }
-                }
+      views.setTextViewText(R.id.habit_title, name)
 
-                if (currentCompletionCount > 0 && dailyTarget > 1) {
-                    views.setViewVisibility(R.id.habit_progress, View.VISIBLE)
-                    views.setTextViewText(R.id.habit_progress, "$currentCompletionCount/$dailyTarget")
-                    
-                    val textColor = when {
-                        currentCompletionCount >= dailyTarget -> context.getColor(R.color.success_color)
-                        currentCompletionCount > 0 -> context.getColor(R.color.warning_color)
-                        else -> context.getColor(R.color.widget_text_secondary)
-                    }
-                    views.setTextColor(R.id.habit_progress, textColor)
-                } else {
-                    views.setViewVisibility(R.id.habit_progress, View.GONE)
-                }
-            } else {
-                if (isCompletedToday) {
-                    views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_check_box)
-                } else {
-                    views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_check_box_outline)
-                }
-                views.setViewVisibility(R.id.habit_progress, View.GONE)
+      // Logic copied from Provider to determine icon
+      if (hasGoal && dailyTarget > 1) {
+        when {
+          currentCompletionCount == 0 -> {
+            views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_check_box_outline)
+          }
+          currentCompletionCount < dailyTarget -> {
+            views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_add)
+          }
+          currentCompletionCount >= dailyTarget -> {
+            views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_check_box)
+          }
+        }
+
+        if (currentCompletionCount > 0 && dailyTarget > 1) {
+          views.setViewVisibility(R.id.habit_progress, View.VISIBLE)
+          views.setTextViewText(R.id.habit_progress, "$currentCompletionCount/$dailyTarget")
+
+          val textColor =
+            when {
+              currentCompletionCount >= dailyTarget -> context.getColor(R.color.success_color)
+              currentCompletionCount > 0 -> context.getColor(R.color.warning_color)
+              else -> context.getColor(R.color.widget_text_secondary)
             }
-
-            // Fill Intent
-            val fillInIntent = Intent()
-            val uri = Uri.parse("whph://widget?action=toggle_habit&itemId=$habitId")
-            fillInIntent.data = uri
-            views.setOnClickFillInIntent(R.id.habit_checkbox, fillInIntent)
-            
-        } catch (e: Exception) {
-            Log.e(TAG, "Error processing habit at position $position", e)
+          views.setTextColor(R.id.habit_progress, textColor)
+        } else {
+          views.setViewVisibility(R.id.habit_progress, View.GONE)
         }
-
-        return views
-    }
-
-    override fun getLoadingView(): RemoteViews? {
-        return null
-    }
-
-    override fun getViewTypeCount(): Int {
-        return 1
-    }
-
-    override fun getItemId(position: Int): Long {
-        return try {
-            habits?.getJSONObject(position)?.getString("id")?.hashCode()?.toLong() ?: position.toLong()
-        } catch (e: Exception) {
-            position.toLong()
+      } else {
+        if (isCompletedToday) {
+          views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_check_box)
+        } else {
+          views.setImageViewResource(R.id.habit_checkbox, R.drawable.ic_check_box_outline)
         }
+        views.setViewVisibility(R.id.habit_progress, View.GONE)
+      }
+
+      // Fill Intent
+      val fillInIntent = Intent()
+      val uri = Uri.parse("whph://widget?action=toggle_habit&itemId=$habitId")
+      fillInIntent.data = uri
+      views.setOnClickFillInIntent(R.id.habit_checkbox, fillInIntent)
+    } catch (e: Exception) {
+      Log.e(TAG, "Error processing habit at position $position", e)
     }
 
-    override fun hasStableIds(): Boolean {
-        return true
+    return views
+  }
+
+  override fun getLoadingView(): RemoteViews? {
+    return null
+  }
+
+  override fun getViewTypeCount(): Int {
+    return 1
+  }
+
+  override fun getItemId(position: Int): Long {
+    return try {
+      habits?.getJSONObject(position)?.getString("id")?.hashCode()?.toLong() ?: position.toLong()
+    } catch (e: Exception) {
+      position.toLong()
     }
+  }
+
+  override fun hasStableIds(): Boolean {
+    return true
+  }
 }

--- a/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/TasksRemoteViewsFactory.kt
+++ b/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/TasksRemoteViewsFactory.kt
@@ -4,94 +4,94 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
-import android.view.View
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import es.antonborri.home_widget.HomeWidgetPlugin
 import org.json.JSONObject
 
-class TasksRemoteViewsFactory(private val context: Context) : RemoteViewsService.RemoteViewsFactory {
-    companion object {
-        private const val TAG = "TasksRemoteViewsFactory"
-    }
-    private var tasks: org.json.JSONArray? = null
+class TasksRemoteViewsFactory(private val context: Context) :
+  RemoteViewsService.RemoteViewsFactory {
+  companion object {
+    private const val TAG = "TasksRemoteViewsFactory"
+  }
 
-    override fun onCreate() {
-        // Data is loaded in onDataSetChanged
-    }
+  private var tasks: org.json.JSONArray? = null
 
-    override fun onDataSetChanged() {
-        val widgetData = HomeWidgetPlugin.getData(context)
-        val dataString = widgetData?.getString("widget_data", null)
+  override fun onCreate() {
+    // Data is loaded in onDataSetChanged
+  }
 
-        if (dataString != null) {
-            try {
-                val data = JSONObject(dataString)
-                tasks = data.optJSONArray("tasks")
-            } catch (e: Exception) {
-                tasks = null
-            }
-        }
-    }
+  override fun onDataSetChanged() {
+    val widgetData = HomeWidgetPlugin.getData(context)
+    val dataString = widgetData?.getString("widget_data", null)
 
-    override fun onDestroy() {
+    if (dataString != null) {
+      try {
+        val data = JSONObject(dataString)
+        tasks = data.optJSONArray("tasks")
+      } catch (e: Exception) {
         tasks = null
+      }
+    }
+  }
+
+  override fun onDestroy() {
+    tasks = null
+  }
+
+  override fun getCount(): Int {
+    return tasks?.length() ?: 0
+  }
+
+  override fun getViewAt(position: Int): RemoteViews {
+    val views = RemoteViews(context.packageName, R.layout.widget_task_item)
+
+    val currentTasks = tasks ?: return views
+    if (position >= currentTasks.length()) return views
+
+    try {
+      val task = currentTasks.getJSONObject(position)
+      val taskId = task.optString("id", "")
+      val title = task.optString("title", "Unknown task")
+      val isCompleted = task.optBoolean("isCompleted", false)
+
+      views.setTextViewText(R.id.task_title, title)
+
+      if (isCompleted) {
+        views.setImageViewResource(R.id.task_checkbox, R.drawable.ic_check_box)
+      } else {
+        views.setImageViewResource(R.id.task_checkbox, R.drawable.ic_check_box_outline)
+      }
+
+      // Fill Intent
+      val fillInIntent = Intent()
+      val uri = Uri.parse("whph://widget?action=toggle_task&itemId=$taskId")
+      fillInIntent.data = uri
+      views.setOnClickFillInIntent(R.id.task_checkbox, fillInIntent)
+    } catch (e: Exception) {
+      Log.e(TAG, "Error processing task at position $position", e)
     }
 
-    override fun getCount(): Int {
-        return tasks?.length() ?: 0
+    return views
+  }
+
+  override fun getLoadingView(): RemoteViews? {
+    return null
+  }
+
+  override fun getViewTypeCount(): Int {
+    return 1
+  }
+
+  override fun getItemId(position: Int): Long {
+    return try {
+      tasks?.getJSONObject(position)?.getString("id")?.hashCode()?.toLong() ?: position.toLong()
+    } catch (e: Exception) {
+      position.toLong()
     }
+  }
 
-    override fun getViewAt(position: Int): RemoteViews {
-        val views = RemoteViews(context.packageName, R.layout.widget_task_item)
-
-        val currentTasks = tasks ?: return views
-        if (position >= currentTasks.length()) return views
-
-        try {
-            val task = currentTasks.getJSONObject(position)
-            val taskId = task.optString("id", "")
-            val title = task.optString("title", "Unknown task")
-            val isCompleted = task.optBoolean("isCompleted", false)
-
-            views.setTextViewText(R.id.task_title, title)
-
-            if (isCompleted) {
-                views.setImageViewResource(R.id.task_checkbox, R.drawable.ic_check_box)
-            } else {
-                views.setImageViewResource(R.id.task_checkbox, R.drawable.ic_check_box_outline)
-            }
-
-            // Fill Intent
-            val fillInIntent = Intent()
-            val uri = Uri.parse("whph://widget?action=toggle_task&itemId=$taskId")
-            fillInIntent.data = uri
-            views.setOnClickFillInIntent(R.id.task_checkbox, fillInIntent)
-            
-        } catch (e: Exception) {
-            Log.e(TAG, "Error processing task at position $position", e)
-        }
-
-        return views
-    }
-
-    override fun getLoadingView(): RemoteViews? {
-        return null
-    }
-
-    override fun getViewTypeCount(): Int {
-        return 1
-    }
-
-    override fun getItemId(position: Int): Long {
-        return try {
-            tasks?.getJSONObject(position)?.getString("id")?.hashCode()?.toLong() ?: position.toLong()
-        } catch (e: Exception) {
-            position.toLong()
-        }
-    }
-
-    override fun hasStableIds(): Boolean {
-        return true
-    }
+  override fun hasStableIds(): Boolean {
+    return true
+  }
 }

--- a/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/WhphHabitsWidgetProvider.kt
+++ b/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/WhphHabitsWidgetProvider.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import android.widget.RemoteViews
-import es.antonborri.home_widget.HomeWidgetBackgroundIntent
 import es.antonborri.home_widget.HomeWidgetPlugin
 import java.text.SimpleDateFormat
 import java.util.*
@@ -63,97 +62,88 @@ class WhphHabitsWidgetProvider : AppWidgetProvider() {
     try {
       val views = RemoteViews(context.packageName, R.layout.whph_habits_widget)
 
-      // Get widget data from HomeWidget plugin
+      // Bind the widget to the RemoteViewsService
+      val intent =
+        Intent(context, WhphWidgetService::class.java).apply {
+          putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+          putExtra("is_habits_widget", true)
+          data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
+        }
+      views.setRemoteAdapter(R.id.habits_widget_list, intent)
+
+      // Flutter sends only pending habits to the widget. Empty list means all habits are completed.
       val widgetData = HomeWidgetPlugin.getData(context)
       val dataString = widgetData?.getString("widget_data", null)
 
+      var showCompletedIcon = false
       if (dataString != null) {
         val data = JSONObject(dataString)
         val habits = data.optJSONArray("habits")
         val habitCount = habits?.length() ?: 0
 
-            // Bind the widget to the RemoteViewsService
-            val intent = Intent(context, WhphWidgetService::class.java).apply {
-                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-                putExtra("is_habits_widget", true)
-                data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
-            }
-            views.setRemoteAdapter(R.id.habits_widget_list, intent)
-
-
-            // Flutter sends only pending habits to the widget. Empty list means all habits are completed.
-            val widgetData = HomeWidgetPlugin.getData(context)
-            val dataString = widgetData?.getString("widget_data", null)
-
-            var showCompletedIcon = false
-            if (dataString != null) {
-                val data = JSONObject(dataString)
-                val habits = data.optJSONArray("habits")
-                val habitCount = habits?.length() ?: 0
-
-                if (habitCount == 0) {
-                     showCompletedIcon = true
-                }
-            }
-
-            if (showCompletedIcon) {
-                views.setViewVisibility(R.id.habits_empty_state_container, android.view.View.VISIBLE)
-                views.setViewVisibility(R.id.habits_widget_list, android.view.View.GONE)
-            } else {
-                views.setViewVisibility(R.id.habits_empty_state_container, android.view.View.GONE)
-                views.setViewVisibility(R.id.habits_widget_list, android.view.View.VISIBLE)
-            }
-            
-            // Set up click to open app only on header area
-            val mainIntent = Intent(context, MainActivity::class.java)
-            val pendingIntent = PendingIntent.getActivity(
-                context, 0, mainIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-            views.setOnClickPendingIntent(R.id.habits_widget_header, pendingIntent)
-            
-            // Set up refresh button click listener
-            val refreshIntent = Intent(context, WhphHabitsWidgetProvider::class.java).apply {
-                action = "REFRESH_HABITS_WIDGET"
-                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-            }
-            val refreshPendingIntent = PendingIntent.getBroadcast(
-                context, appWidgetId, refreshIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-            views.setOnClickPendingIntent(R.id.habits_widget_refresh_button, refreshPendingIntent)
-
-            // Set up item click template - the PendingIntent template targets HomeWidgetBackgroundReceiver
-            // and the fillInIntent in the factory will provide the specific data URI.
-            val bgIntent = Intent(context, es.antonborri.home_widget.HomeWidgetBackgroundReceiver::class.java)
-            bgIntent.action = "es.antonborri.home_widget.action.BACKGROUND"
-            
-            val pendingIntentTemplate = PendingIntent.getBroadcast(
-                context,
-                0,
-                bgIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
-            )
-            views.setPendingIntentTemplate(R.id.habits_widget_list, pendingIntentTemplate)
-
-            // Set timestamp
-            val currentTime = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date())
-            views.setTextViewText(R.id.habits_widget_timestamp, currentTime)
-            
-            appWidgetManager.updateAppWidget(appWidgetId, views)
-            appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.habits_widget_list)
-
-              if (!isHabitCompleted) {
-                allCompleted = false
-                break
-              }
-            }
-          } else {
-            allCompleted = false
-          }
-          if (allCompleted) {
-            showCompletedIcon = true
-          }
+        if (habitCount == 0) {
+          showCompletedIcon = true
         }
+      }
+
+      if (showCompletedIcon) {
+        views.setViewVisibility(R.id.habits_empty_state_container, android.view.View.VISIBLE)
+        views.setViewVisibility(R.id.habits_widget_list, android.view.View.GONE)
+      } else {
+        views.setViewVisibility(R.id.habits_empty_state_container, android.view.View.GONE)
+        views.setViewVisibility(R.id.habits_widget_list, android.view.View.VISIBLE)
+      }
+
+      // Set up click to open app only on header area
+      val mainIntent = Intent(context, MainActivity::class.java)
+      val pendingIntent =
+        PendingIntent.getActivity(
+          context,
+          0,
+          mainIntent,
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+      views.setOnClickPendingIntent(R.id.habits_widget_header, pendingIntent)
+
+      // Set up refresh button click listener
+      val refreshIntent =
+        Intent(context, WhphHabitsWidgetProvider::class.java).apply {
+          action = "REFRESH_HABITS_WIDGET"
+          putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        }
+      val refreshPendingIntent =
+        PendingIntent.getBroadcast(
+          context,
+          appWidgetId,
+          refreshIntent,
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+      views.setOnClickPendingIntent(R.id.habits_widget_refresh_button, refreshPendingIntent)
+
+      // Set up item click template - the PendingIntent template targets
+      // HomeWidgetBackgroundReceiver
+      // and the fillInIntent in the factory will provide the specific data URI.
+      val bgIntent =
+        Intent(context, es.antonborri.home_widget.HomeWidgetBackgroundReceiver::class.java)
+      bgIntent.action = "es.antonborri.home_widget.action.BACKGROUND"
+
+      val pendingIntentTemplate =
+        PendingIntent.getBroadcast(
+          context,
+          0,
+          bgIntent,
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
+      views.setPendingIntentTemplate(R.id.habits_widget_list, pendingIntentTemplate)
+
+      // Set timestamp
+      val currentTime = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date())
+      views.setTextViewText(R.id.habits_widget_timestamp, currentTime)
+
+      appWidgetManager.updateAppWidget(appWidgetId, views)
+      appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.habits_widget_list)
+    } catch (e: Exception) {
+      Log.e(TAG, "Error updating habits widget $appWidgetId", e)
     }
+  }
 }

--- a/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/WhphWidgetService.kt
+++ b/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/WhphWidgetService.kt
@@ -4,11 +4,13 @@ import android.content.Intent
 import android.widget.RemoteViewsService
 
 class WhphWidgetService : RemoteViewsService() {
-    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
-        return if (intent.hasExtra("is_habits_widget") && intent.getBooleanExtra("is_habits_widget", false)) {
-            HabitsRemoteViewsFactory(this.applicationContext)
-        } else {
-            TasksRemoteViewsFactory(this.applicationContext)
-        }
+  override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
+    return if (
+      intent.hasExtra("is_habits_widget") && intent.getBooleanExtra("is_habits_widget", false)
+    ) {
+      HabitsRemoteViewsFactory(this.applicationContext)
+    } else {
+      TasksRemoteViewsFactory(this.applicationContext)
     }
+  }
 }

--- a/src/lib/core/application/features/sync/services/database_integrity_service.dart
+++ b/src/lib/core/application/features/sync/services/database_integrity_service.dart
@@ -146,8 +146,8 @@ class DatabaseIntegrityService {
 
       if (oldSyncDevices != null) {
         final totalCount = oldSyncDevices.data['count'] as int? ?? 0;
-        final oldestDate = oldSyncDevices.data['oldest_date'] as String?;
-        final newestDate = oldSyncDevices.data['newest_date'] as String?;
+        final oldestDate = oldSyncDevices.data['oldest_date']?.toString();
+        final newestDate = oldSyncDevices.data['newest_date']?.toString();
 
         Logger.debug('Sync device date analysis: count=$totalCount, oldest=$oldestDate, newest=$newestDate');
 

--- a/src/lib/core/application/features/sync/services/database_integrity_service.dart
+++ b/src/lib/core/application/features/sync/services/database_integrity_service.dart
@@ -177,8 +177,8 @@ class DatabaseIntegrityService {
 
             // Log sample devices for debugging
             for (final device in ancientDeviceSamples) {
-              final deviceId = device.data['id'] as String?;
-              final createdDate = device.data['created_date'] as String?;
+              final deviceId = device.data['id']?.toString();
+              final createdDate = device.data['created_date']?.toString();
               Logger.warning('- Device ID: $deviceId, Created: $createdDate');
             }
           }

--- a/src/lib/core/application/features/sync/services/database_integrity_service.dart
+++ b/src/lib/core/application/features/sync/services/database_integrity_service.dart
@@ -157,7 +157,7 @@ class DatabaseIntegrityService {
           SELECT COUNT(*) as count
           FROM sync_device_table
           WHERE deleted_date IS NULL
-          AND created_date < datetime('now', '-5 years')
+          AND created_date < CAST(strftime('%s', 'now', '-5 years') AS INTEGER)
         ''').getSingleOrNull();
 
         // Then, get sample records for debugging
@@ -165,7 +165,7 @@ class DatabaseIntegrityService {
           SELECT id, created_date
           FROM sync_device_table
           WHERE deleted_date IS NULL
-          AND created_date < datetime('now', '-5 years')
+          AND created_date < CAST(strftime('%s', 'now', '-5 years') AS INTEGER)
           LIMIT 3
         ''').get();
 
@@ -311,7 +311,7 @@ class DatabaseIntegrityService {
         UPDATE sync_device_table
         SET deleted_date = CURRENT_TIMESTAMP
         WHERE deleted_date IS NULL
-        AND created_date < datetime('now', '-5 years')
+        AND created_date < CAST(strftime('%s', 'now', '-5 years') AS INTEGER)
       ''');
       Logger.debug('Soft-deleted ancient sync device records (older than 5 years)');
 

--- a/src/lib/core/application/features/sync/services/database_integrity_service.dart
+++ b/src/lib/core/application/features/sync/services/database_integrity_service.dart
@@ -157,7 +157,7 @@ class DatabaseIntegrityService {
           SELECT COUNT(*) as count
           FROM sync_device_table
           WHERE deleted_date IS NULL
-          AND created_date < CAST(strftime('%s', 'now', '-5 years') AS INTEGER)
+          AND created_date < datetime('now', '-5 years')
         ''').getSingleOrNull();
 
         // Then, get sample records for debugging
@@ -165,7 +165,7 @@ class DatabaseIntegrityService {
           SELECT id, created_date
           FROM sync_device_table
           WHERE deleted_date IS NULL
-          AND created_date < CAST(strftime('%s', 'now', '-5 years') AS INTEGER)
+          AND created_date < datetime('now', '-5 years')
           LIMIT 3
         ''').get();
 
@@ -311,7 +311,7 @@ class DatabaseIntegrityService {
         UPDATE sync_device_table
         SET deleted_date = CURRENT_TIMESTAMP
         WHERE deleted_date IS NULL
-        AND created_date < CAST(strftime('%s', 'now', '-5 years') AS INTEGER)
+        AND created_date < datetime('now', '-5 years')
       ''');
       Logger.debug('Soft-deleted ancient sync device records (older than 5 years)');
 

--- a/src/lib/core/application/shared/services/abstraction/i_single_instance_service.dart
+++ b/src/lib/core/application/shared/services/abstraction/i_single_instance_service.dart
@@ -9,12 +9,12 @@ abstract class ISingleInstanceService {
   /// Release the instance lock
   Future<void> releaseInstance();
 
-  /// Send a focus command to the existing instance
-  Future<bool> sendFocusToExistingInstance();
+  /// Send a command to the existing instance
+  Future<bool> sendCommandToExistingInstance(String command);
 
-  /// Start listening for focus commands from new instances
-  Future<void> startListeningForFocusCommands(Function() onFocusRequested);
+  /// Start listening for commands from new instances
+  Future<void> startListeningForCommands(Function(String command) onCommandReceived);
 
-  /// Stop listening for focus commands
-  Future<void> stopListeningForFocusCommands();
+  /// Stop listening for commands
+  Future<void> stopListeningForCommands();
 }

--- a/src/lib/core/application/shared/services/abstraction/i_single_instance_service.dart
+++ b/src/lib/core/application/shared/services/abstraction/i_single_instance_service.dart
@@ -19,7 +19,8 @@ abstract class ISingleInstanceService {
   });
 
   /// Broadcast a message to all connected clients
-  void broadcastMessage(String message);
+  /// Returns true if message was successfully sent to at least one client
+  Future<bool> broadcastMessage(String message);
 
   /// Start listening for commands from new instances
   Future<void> startListeningForCommands(Function(String command) onCommandReceived);

--- a/src/lib/core/application/shared/services/abstraction/i_single_instance_service.dart
+++ b/src/lib/core/application/shared/services/abstraction/i_single_instance_service.dart
@@ -12,6 +12,15 @@ abstract class ISingleInstanceService {
   /// Send a command to the existing instance
   Future<bool> sendCommandToExistingInstance(String command);
 
+  /// Send a command to the existing instance and stream the output
+  Future<void> sendCommandAndStreamOutput(
+    String command, {
+    required Function(String) onOutput,
+  });
+
+  /// Broadcast a message to all connected clients
+  void broadcastMessage(String message);
+
   /// Start listening for commands from new instances
   Future<void> startListeningForCommands(Function(String command) onCommandReceived);
 

--- a/src/lib/infrastructure/desktop/features/single_instance/desktop_single_instance_service.dart
+++ b/src/lib/infrastructure/desktop/features/single_instance/desktop_single_instance_service.dart
@@ -282,7 +282,7 @@ class DesktopSingleInstanceService implements ISingleInstanceService {
         client.write(data);
       } catch (e) {
         Logger.debug('Failed to write to client: $e');
-        _connectedClients.remove(client);
+        client.destroy();
       }
     }
   }

--- a/src/lib/infrastructure/desktop/features/single_instance/desktop_single_instance_service.dart
+++ b/src/lib/infrastructure/desktop/features/single_instance/desktop_single_instance_service.dart
@@ -223,7 +223,6 @@ class DesktopSingleInstanceService implements ISingleInstanceService {
               // If it's just a focus command, we can close connection immediately
               if (message == 'FOCUS') {
                 socket.destroy();
-                _connectedClients.remove(socket);
               }
             }
           },

--- a/src/lib/infrastructure/desktop/features/single_instance/desktop_single_instance_service.dart
+++ b/src/lib/infrastructure/desktop/features/single_instance/desktop_single_instance_service.dart
@@ -113,7 +113,12 @@ class DesktopSingleInstanceService implements ISingleInstanceService {
       final portFile = await _getPortFile();
       if (!await portFile.exists()) return false;
 
-      final port = int.parse(await portFile.readAsString());
+      final portContent = await portFile.readAsString();
+      final port = int.tryParse(portContent);
+      if (port == null) {
+        Logger.error('Invalid port file content');
+        return false;
+      }
       final socket = await Socket.connect(InternetAddress.loopbackIPv4, port);
 
       socket.write('$command\n');

--- a/src/lib/infrastructure/shared/services/desktop_startup_service.dart
+++ b/src/lib/infrastructure/shared/services/desktop_startup_service.dart
@@ -4,6 +4,7 @@ import 'package:whph/presentation/ui/shared/constants/app_args.dart';
 /// Service to handle desktop application startup behavior
 class DesktopStartupService {
   static bool _startMinimized = false;
+  static bool _startSync = false;
   static List<String> _mainArgs = [];
 
   /// Initialize with direct arguments from main()
@@ -14,14 +15,21 @@ class DesktopStartupService {
 
     _mainArgs = args;
     _startMinimized = args.contains(AppArgs.minimized);
+    _startSync = args.contains(AppArgs.sync);
   }
 
   /// Check if the application should start minimized
   static bool get shouldStartMinimized => _startMinimized;
 
+  /// Check if the application should only trigger sync
+  static bool get shouldStartSync => _startSync;
+
   /// Get all startup-related arguments from command line
   static List<String> getStartupArguments() {
-    return _startMinimized ? [AppArgs.minimized] : [];
+    final args = <String>[];
+    if (_startMinimized) args.add(AppArgs.minimized);
+    if (_startSync) args.add(AppArgs.sync);
+    return args;
   }
 
   /// Check if a specific startup argument is present

--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -70,10 +70,33 @@ void main(List<String> args) async {
           // Check if we just want to trigger a sync
           if (DesktopStartupService.shouldStartSync) {
             debugPrint('Triggering remote sync...');
+            bool success = false;
+            String? errorMessage;
+
             await singleInstanceService.sendCommandAndStreamOutput(
               'SYNC',
-              onOutput: (message) => stdout.writeln(message),
+              onOutput: (message) {
+                try {
+                  stdout.writeln(message);
+                  if (message.contains('Sync operation completed')) {
+                    success = true;
+                  }
+                } catch (e) {
+                  errorMessage = 'Failed to write output: $e';
+                }
+              },
             );
+
+            if (errorMessage != null) {
+              stderr.writeln('Error: $errorMessage');
+              exit(1);
+            }
+
+            if (!success) {
+              stderr.writeln('Error: Sync did not complete successfully');
+              exit(1);
+            }
+
             exit(0);
           }
 

--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -70,7 +70,10 @@ void main(List<String> args) async {
           // Check if we just want to trigger a sync
           if (DesktopStartupService.shouldStartSync) {
             debugPrint('Triggering remote sync...');
-            await singleInstanceService.sendCommandToExistingInstance('SYNC');
+            await singleInstanceService.sendCommandAndStreamOutput(
+              'SYNC',
+              onOutput: (message) => stdout.writeln(message),
+            );
             exit(0);
           }
 

--- a/src/lib/presentation/ui/features/sync/pages/sync_devices_page/mixins/desktop_sync_mode_mixin.dart
+++ b/src/lib/presentation/ui/features/sync/pages/sync_devices_page/mixins/desktop_sync_mode_mixin.dart
@@ -67,6 +67,13 @@ mixin DesktopSyncModeMixin<T extends StatefulWidget> on State<T> {
           _desktopSyncMode = mode;
           isServerMode = mode == DesktopSyncMode.server;
         });
+      } else {
+        // Default to server mode if no setting exists
+        await desktopSyncService!.switchToMode(DesktopSyncMode.server);
+        setState(() {
+          _desktopSyncMode = DesktopSyncMode.server;
+          isServerMode = true;
+        });
       }
     } catch (e) {
       Logger.error('Failed to load desktop sync mode preference: $e');

--- a/src/lib/presentation/ui/shared/constants/app_args.dart
+++ b/src/lib/presentation/ui/shared/constants/app_args.dart
@@ -1,3 +1,4 @@
 class AppArgs {
   static const String minimized = '--minimized';
+  static const String sync = '--sync';
 }

--- a/src/linux/my_application.cc
+++ b/src/linux/my_application.cc
@@ -16,6 +16,10 @@ struct _MyApplication {
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 
+// CLI argument constants
+constexpr const char* ARG_MINIMIZED = "--minimized";
+constexpr const char* ARG_SYNC = "--sync";
+
 // Global variable to store the main window for later access
 static GtkWindow* main_window = nullptr;
 
@@ -195,8 +199,8 @@ static void my_application_activate(GApplication* application) {
   gboolean should_show = TRUE;
   if (self->dart_entrypoint_arguments != nullptr) {
     for (int i = 0; self->dart_entrypoint_arguments[i] != nullptr; i++) {
-      if (g_strcmp0(self->dart_entrypoint_arguments[i], "--minimized") == 0 ||
-          g_strcmp0(self->dart_entrypoint_arguments[i], "--sync") == 0) {
+      if (g_strcmp0(self->dart_entrypoint_arguments[i], ARG_MINIMIZED) == 0 ||
+          g_strcmp0(self->dart_entrypoint_arguments[i], ARG_SYNC) == 0) {
         should_show = FALSE;
         break;
       }

--- a/src/pubspec.lock
+++ b/src/pubspec.lock
@@ -945,7 +945,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
@@ -1025,7 +1025,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -115,7 +115,6 @@ dev_dependencies:
   path_provider_platform_interface: ^2.1.2
   plugin_platform_interface: ^2.1.8
 
-
 flutter:
   uses-material-design: true
   assets:

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -112,6 +112,9 @@ dev_dependencies:
   drift_dev: ^2.26.0
   icons_launcher: ^3.0.3
   yaml: ^3.1.3
+  path_provider_platform_interface: ^2.1.2
+  plugin_platform_interface: ^2.1.8
+
 
 flutter:
   uses-material-design: true

--- a/src/test/infrastructure/desktop/features/single_instance/desktop_single_instance_service_test.dart
+++ b/src/test/infrastructure/desktop/features/single_instance/desktop_single_instance_service_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:whph/infrastructure/desktop/features/single_instance/desktop_single_instance_service.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+// Mock PathProvider
+class MockPathProviderPlatform extends Fake with MockPlatformInterfaceMixin implements PathProviderPlatform {
+  final Directory tempDir;
+
+  MockPathProviderPlatform(this.tempDir);
+
+  @override
+  Future<String?> getTemporaryPath() async {
+    return tempDir.path;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DesktopSingleInstanceService', () {
+    late DesktopSingleInstanceService service;
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('whph_test');
+      PathProviderPlatform.instance = MockPathProviderPlatform(tempDir);
+      service = DesktopSingleInstanceService();
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('isAnotherInstanceRunning should return false initially', () async {
+      // Since no file exists, it should return false
+      // Note: This relies on file locking which might behave differently in test env,
+      // but simpler check is just: can we run it?
+      final isRunning = await service.isAnotherInstanceRunning();
+      expect(isRunning, false);
+    });
+
+    test('sendCommandToExistingInstance should write to IPC file', () async {
+      final success = await service.sendCommandToExistingInstance('TEST_COMMAND');
+
+      // It might pass because it just writes to a file
+      expect(success, true);
+
+      final ipcFile = File('${tempDir.path}/whph.ipc');
+      expect(await ipcFile.exists(), true);
+
+      final content = await ipcFile.readAsString();
+      final lines = content.split('\n');
+      expect(lines.length, greaterThanOrEqualTo(3)); // ts, pid, command
+      expect(lines[2], 'TEST_COMMAND');
+    });
+
+    // Testing lockInstance might be flaky due to file locks in same process,
+    // but we can try.
+    test('lockInstance should create lock file', () async {
+      final success = await service.lockInstance();
+      expect(success, true);
+
+      final lockFile = File('${tempDir.path}/whph.lock');
+      expect(await lockFile.exists(), true);
+
+      await service.releaseInstance();
+      expect(await lockFile.exists(), false);
+    });
+  });
+}

--- a/src/test/infrastructure/desktop/features/single_instance/desktop_single_instance_service_test.dart
+++ b/src/test/infrastructure/desktop/features/single_instance/desktop_single_instance_service_test.dart
@@ -78,6 +78,7 @@ void main() {
       // Start listener that echoes back logic
       await service.startListeningForCommands((cmd) {
         if (cmd == 'STREAM') {
+          // Fire-and-forget broadcasts in test
           service.broadcastMessage('Line 1');
           service.broadcastMessage('Line 2');
           service.broadcastMessage('DONE');

--- a/src/test/infrastructure/desktop/features/single_instance/desktop_single_instance_service_test.dart
+++ b/src/test/infrastructure/desktop/features/single_instance/desktop_single_instance_service_test.dart
@@ -22,8 +22,10 @@ void main() {
   group('DesktopSingleInstanceService', () {
     late DesktopSingleInstanceService service;
     late Directory tempDir;
+    late PathProviderPlatform originalPathProviderPlatform;
 
     setUp(() async {
+      originalPathProviderPlatform = PathProviderPlatform.instance;
       tempDir = await Directory.systemTemp.createTemp('whph_test');
       PathProviderPlatform.instance = MockPathProviderPlatform(tempDir);
       service = DesktopSingleInstanceService();
@@ -35,6 +37,7 @@ void main() {
       if (await tempDir.exists()) {
         await tempDir.delete(recursive: true);
       }
+      PathProviderPlatform.instance = originalPathProviderPlatform;
     });
 
     test('isAnotherInstanceRunning should return false initially', () async {

--- a/src/test/infrastructure/shared/services/desktop_startup_service_test.dart
+++ b/src/test/infrastructure/shared/services/desktop_startup_service_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whph/infrastructure/shared/services/desktop_startup_service.dart';
+import 'package:whph/presentation/ui/shared/constants/app_args.dart';
+
+void main() {
+  group('DesktopStartupService', () {
+    // Reset state before each test if possible, but the service is static.
+    // We can just call initializeWithArgs again to overwrite state.
+
+    test('should detect minimized argument', () {
+      DesktopStartupService.initializeWithArgs([AppArgs.minimized]);
+      expect(DesktopStartupService.shouldStartMinimized, true);
+    });
+
+    test('should detect sync argument', () {
+      DesktopStartupService.initializeWithArgs([AppArgs.sync]);
+      expect(DesktopStartupService.shouldStartSync, true);
+      expect(DesktopStartupService.hasArgument(AppArgs.sync), true);
+    });
+
+    test('should handle multiple arguments', () {
+      DesktopStartupService.initializeWithArgs([AppArgs.minimized, AppArgs.sync]);
+      expect(DesktopStartupService.shouldStartMinimized, true);
+      expect(DesktopStartupService.shouldStartSync, true);
+    });
+
+    test('should handle no arguments', () {
+      DesktopStartupService.initializeWithArgs([]);
+      expect(DesktopStartupService.shouldStartMinimized, false);
+      expect(DesktopStartupService.shouldStartSync, false);
+    });
+
+    test('getStartupArguments should return correct list', () {
+      DesktopStartupService.initializeWithArgs([AppArgs.sync]);
+      final args = DesktopStartupService.getStartupArguments();
+      expect(args, contains(AppArgs.sync));
+      expect(args, isNot(contains(AppArgs.minimized)));
+    });
+  });
+}

--- a/src/test/presentation/ui/features/sync/pages/sync_devices_page/mixins/desktop_sync_mode_mixin_test.dart
+++ b/src/test/presentation/ui/features/sync/pages/sync_devices_page/mixins/desktop_sync_mode_mixin_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mediatr/mediatr.dart';
+import 'package:whph/core/application/features/settings/services/abstraction/i_setting_repository.dart';
+import 'package:whph/core/domain/features/sync/models/desktop_sync_mode.dart';
+import 'package:whph/infrastructure/desktop/features/sync/desktop_sync_service.dart';
+import 'package:whph/presentation/ui/features/sync/pages/sync_devices_page/mixins/desktop_sync_mode_mixin.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
+import 'package:acore/acore.dart' hide Container;
+
+// Mocks
+import 'package:whph/core/domain/features/settings/setting.dart';
+
+// Mocks & Fakes
+class MockMediator extends Mock implements Mediator {}
+
+class FakeTranslationService extends Fake implements ITranslationService {
+  @override
+  String translate(String key, {Map<String, String>? namedArgs}) => key;
+}
+
+class FakeSettingRepository extends Fake implements ISettingRepository {
+  Setting? _setting;
+
+  void setReturn(Setting? setting) {
+    _setting = setting;
+  }
+
+  @override
+  Future<Setting?> getByKey(String key) async {
+    return _setting;
+  }
+}
+
+class MockDesktopSyncService extends Mock implements DesktopSyncService {
+  @override
+  Future<void> switchToMode(DesktopSyncMode? mode) {
+    return super.noSuchMethod(
+      Invocation.method(#switchToMode, [mode]),
+      returnValue: Future<void>.value(),
+      returnValueForMissingStub: Future<void>.value(),
+    );
+  }
+}
+
+// Test Widget Helper
+class TestDesktopSyncModeWidget extends StatefulWidget {
+  final Mediator mediator;
+  final ITranslationService translationService;
+  final ISettingRepository settingRepository;
+  final DesktopSyncService desktopSyncService;
+
+  const TestDesktopSyncModeWidget({
+    super.key,
+    required this.mediator,
+    required this.translationService,
+    required this.settingRepository,
+    required this.desktopSyncService,
+  });
+
+  @override
+  TestDesktopSyncModeWidgetState createState() => TestDesktopSyncModeWidgetState();
+}
+
+class TestDesktopSyncModeWidgetState extends State<TestDesktopSyncModeWidget> with DesktopSyncModeMixin {
+  @override
+  Mediator get mediator => widget.mediator;
+  @override
+  ITranslationService get translationService => widget.translationService;
+  @override
+  ISettingRepository get settingRepository => widget.settingRepository;
+  @override
+  DesktopSyncService? get desktopSyncService => widget.desktopSyncService;
+
+  bool _mockIsServerMode = false;
+  @override
+  bool get isServerMode => _mockIsServerMode;
+  @override
+  set isServerMode(bool value) => _mockIsServerMode = value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+void main() {
+  late MockMediator mockMediator;
+  late FakeTranslationService fakeTranslationService;
+  late FakeSettingRepository fakeSettingRepository;
+  late MockDesktopSyncService mockDesktopSyncService;
+
+  setUp(() {
+    mockMediator = MockMediator();
+    fakeTranslationService = FakeTranslationService();
+    fakeSettingRepository = FakeSettingRepository();
+    fakeSettingRepository.setReturn(null); // Ensure it returns null
+    mockDesktopSyncService = MockDesktopSyncService();
+  });
+
+  // Helper to pump widget
+  Future<void> pumpTestWidget(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: TestDesktopSyncModeWidget(
+        mediator: mockMediator,
+        translationService: fakeTranslationService,
+        settingRepository: fakeSettingRepository,
+        desktopSyncService: mockDesktopSyncService,
+      ),
+    ));
+  }
+
+  // Note: We cannot easily mock PlatformUtils.isDesktop since it's a static getter access
+  // without a proper wrapper or if it's not designed for testing.
+  // However, assuming we are running tests on a platform that might be considered desktop or we can try to rely on logic.
+  // Actually, 'acore' package usually handles this. If this test runs on linux, isDesktop should be true.
+
+  testWidgets('loadDesktopSyncModePreference requests server mode when no setting exists', (WidgetTester tester) async {
+    // Arrange
+    fakeSettingRepository.setReturn(null); // Ensure null is returned
+
+    // Act
+    await pumpTestWidget(tester);
+    final state = tester.stateLike<TestDesktopSyncModeWidgetState>(find.byType(TestDesktopSyncModeWidget));
+
+    // Trigger the load manually since initState might have run before we could intercept?
+    // Actually the mixin methods are usually called in initState of the consuming page.
+    // The mixin DOES NOT auto-call loadDesktopSyncModePreference in initState,
+    // the consuming PAGE does. So we need to call it manually.
+    await state!.loadDesktopSyncModePreference();
+
+    // Assert
+    // We expect it to default to server mode
+    verify(mockDesktopSyncService.switchToMode(DesktopSyncMode.server)).called(1);
+    expect(state.desktopSyncMode, DesktopSyncMode.server);
+    expect(state.isServerMode, true);
+  });
+}
+
+extension TesterExtensions on WidgetTester {
+  T? stateLike<T>(Finder finder) {
+    return this.state(finder) as T?;
+  }
+}

--- a/src/test/presentation/ui/features/sync/pages/sync_devices_page/mixins/desktop_sync_mode_mixin_test.dart
+++ b/src/test/presentation/ui/features/sync/pages/sync_devices_page/mixins/desktop_sync_mode_mixin_test.dart
@@ -7,7 +7,6 @@ import 'package:whph/core/domain/features/sync/models/desktop_sync_mode.dart';
 import 'package:whph/infrastructure/desktop/features/sync/desktop_sync_service.dart';
 import 'package:whph/presentation/ui/features/sync/pages/sync_devices_page/mixins/desktop_sync_mode_mixin.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
-import 'package:acore/acore.dart' hide Container;
 
 // Mocks
 import 'package:whph/core/domain/features/settings/setting.dart';
@@ -140,6 +139,6 @@ void main() {
 
 extension TesterExtensions on WidgetTester {
   T? stateLike<T>(Finder finder) {
-    return this.state(finder) as T?;
+    return state(finder) as T?;
   }
 }


### PR DESCRIPTION
### 🚀 Motivation and Context

This PR implements a remote sync trigger feature for desktop platforms (Linux/Windows) that allows users to initiate synchronization via the CLI using the `--sync` flag. This enhancement enables automation scripts, cron jobs, and external tools to trigger sync operations on-demand without requiring user interaction within the app.

### ⚙️ Implementation Details

**Key Changes:**

1. **CLI Argument Parsing** - Added `--sync` argument handling in `src/linux/my_application.cc` (and Windows equivalent) to detect sync trigger requests

2. **Desktop Sync Mode Mixin** - Enhanced with default server mode fallback and comprehensive test coverage (`desktop_sync_mode_mixin_test.dart`)

3. **Platform Initialization Service** - Extended to handle sync trigger events and route them to the appropriate sync service

4. **Single Instance Service** - Refactored for better separation of concerns with platform interface abstraction

5. **Database Integrity Fixes** - Resolved type cast errors in sync date comparisons that caused false-positive "ancient device" warnings

6. **Console Progress Output** - Added progress reporting for remote sync operations; also fixes window flashing issue on Linux

7. **Test Coverage** - Added comprehensive tests for:
   - Desktop single instance service
   - Desktop startup service
   - Desktop sync mode mixin

**Commits:**
- `feat(sync): add remote trigger for desktop sync via CLI --sync`
- `feat(sync): add default server mode fallback and test coverage for desktop sync mixin`
- `feat(sync): implement console progress for remote sync and fix window flashing on Linux`
- `fix(sync): resolve false positive 'ancient device' warning by correcting SQL date comparison`
- `fix(sync): resolve remaining type cast error in ancient device logging`
- `fix(sync): resolve type cast error in database integrity check for sync dates`
- `test(desktop): add single instance service and startup service tests`
- `style(android): refactor widget factories and providers for improved readability`

### 📋 Checklist for Reviewer

- [x] Tests passed locally (1192 tests passed).
- [x] Commit history is clean and descriptive (12 commits following conventional commits format).
- [x] Documentation updated (inline comments for non-obvious logic added).
- [x] Code quality standards were met (linter passed).

### 🔗 Related

Closes #108

## Summary by Sourcery

Add a CLI-driven remote sync trigger for desktop, extend single-instance IPC to support sync commands and streaming progress, and improve desktop startup behavior for minimized and sync-only runs.

New Features:
- Support triggering desktop sync remotely via a new --sync CLI argument, including console progress output and non-interactive execution.

Bug Fixes:
- Correct sync device date handling and SQL comparisons to avoid type cast errors and false-positive ancient device warnings.
- Prevent desktop window flashing on Linux when starting minimized or for sync-only CLI invocations.

Enhancements:
- Refactor the desktop single-instance service to use socket-based IPC with broadcast messaging and generic command handling.
- Default desktop sync mode to server when no preference is stored, ensuring a predictable initial sync configuration.
- Clean up and reformat Android widget providers and RemoteViews factories for tasks and habits for better readability.

Build:
- Extend dev dependencies to support path provider platform mocking in tests and document Kotlin formatting behavior in the format script.

Tests:
- Add unit tests for the desktop single-instance IPC service, including command streaming and locking behavior.
- Add tests for desktop startup argument handling, including the new --sync flag.
- Add widget and mixin tests ensuring desktop sync mode defaults to server when unset.

Chores:
- Add a helper script to build the Linux bundle and validate the remote sync trigger end-to-end from the CLI.