### PR TITLE
feat(app_usages): add option to use tag colors for app usage bars

### DIFF
--- a/src/lib/presentation/ui/features/app_usages/assets/locales/cs.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/cs.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Trvání
     name: Název
     device: Zařízení
+  list_options:
+    use_tag_color_for_bars: Použít barvy značek
+    use_tag_color_for_bars_tooltip: Zobrazit pruhy s barvou jejich značek místo jejich vlastních barev

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/da.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/da.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Varighed
     name: Navn
     device: Enhed
+  list_options:
+    use_tag_color_for_bars: Brug mærkefarver
+    use_tag_color_for_bars_tooltip: Vis søjler med farven fra deres mærker i stedet for deres egne farver

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/de.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/de.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Dauer
     name: Name
     device: Gerät
+  list_options:
+    use_tag_color_for_bars: Tag-Farben verwenden
+    use_tag_color_for_bars_tooltip: Balken in den Farben ihrer Tags statt ihren eigenen Farben anzeigen

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/el.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/el.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Διάρκεια
     name: Όνομα
     device: Συσκευή
+  list_options:
+    use_tag_color_for_bars: Χρήση χρωμάτων ετικετών
+    use_tag_color_for_bars_tooltip: Εμφάνιση ράβδων με το χρώμα των ετικετών τους αντί για τα δικά τους χρώματα

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/en.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/en.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Duration
     name: Name
     device: Device
+  list_options:
+    use_tag_color_for_bars: Use tag colors
+    use_tag_color_for_bars_tooltip: Show bars with the color of their tags instead of their own colors

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/es.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/es.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Duración
     name: Nombre
     device: Dispositivo
+  list_options:
+    use_tag_color_for_bars: Usar colores de etiquetas
+    use_tag_color_for_bars_tooltip: Mostrar barras con el color de sus etiquetas en lugar de sus propios colores

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/fi.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/fi.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Kesto
     name: Nimi
     device: Laite
+  list_options:
+    use_tag_color_for_bars: Käytä tagien värejä
+    use_tag_color_for_bars_tooltip: Näytä palkit tagiensa väreinä oman värinsä sijaan

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/fr.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/fr.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Durée
     name: Nom
     device: Appareil
+  list_options:
+    use_tag_color_for_bars: Utiliser les couleurs des étiquettes
+    use_tag_color_for_bars_tooltip: Afficher les barres avec la couleur de leurs étiquettes au lieu de leurs propres couleurs

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/it.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/it.yaml
@@ -190,3 +190,6 @@ app_usages:
     duration: Durata
     name: Nome
     device: Dispositivo
+  list_options:
+    use_tag_color_for_bars: Usa colori dei tag
+    use_tag_color_for_bars_tooltip: Mostra barre con il colore dei loro tag invece dei loro colori

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/ja.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/ja.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: 期間
     name: 名前
     device: デバイス
+  list_options:
+    use_tag_color_for_bars: タグの色を使用
+    use_tag_color_for_bars_tooltip: 独自の色の代わりにタグの色でバーを表示します

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/ko.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/ko.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: 기간
     name: 이름
     device: 장치
+  list_options:
+    use_tag_color_for_bars: 태그 색상 사용
+    use_tag_color_for_bars_tooltip: 자체 색상 대신 태그의 색상으로 막대를 표시합니다

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/nl.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/nl.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Duur
     name: Naam
     device: Apparaat
+  list_options:
+    use_tag_color_for_bars: Tag-kleuren gebruiken
+    use_tag_color_for_bars_tooltip: Balken weergeven met de kleur van hun tags in plaats van hun eigen kleuren

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/no.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/no.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Varighet
     name: Navn
     device: Enhet
+  list_options:
+    use_tag_color_for_bars: Bruk merkefarger
+    use_tag_color_for_bars_tooltip: Vis stolper med fargen til merkene deres i stedet for deres egne farger

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/pl.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/pl.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Czas trwania
     name: Nazwa
     device: Urządzenie
+  list_options:
+    use_tag_color_for_bars: Użyj kolorów tagów
+    use_tag_color_for_bars_tooltip: Pokaż paski z kolorem ich tagów zamiast ich własnych kolorów

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/pt.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/pt.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Duração
     name: Nome
     device: Dispositivo
+  list_options:
+    use_tag_color_for_bars: Usar cores das tags
+    use_tag_color_for_bars_tooltip: Mostrar barras com a cor das suas tags em vez das suas próprias cores

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/ro.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/ro.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Durată
     name: Nume
     device: Dispozitiv
+  list_options:
+    use_tag_color_for_bars: Folosește culorile etichetelor
+    use_tag_color_for_bars_tooltip: Afișează barele cu culoarea etichetelor lor în loc de propriile lor culori

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/ru.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/ru.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Продолжительность
     name: Имя
     device: Устройство
+  list_options:
+    use_tag_color_for_bars: Использовать цвета тегов
+    use_tag_color_for_bars_tooltip: Показывать полосы цветом их тегов вместо их собственного цвета

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/sl.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/sl.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Trajanje
     name: Ime
     device: Naprava
+  list_options:
+    use_tag_color_for_bars: Uporabi barve oznak
+    use_tag_color_for_bars_tooltip: Prikaži palice z barvami njihovih oznak namesto njihovih lastnih barv

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/sv.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/sv.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Varaktighet
     name: Namn
     device: Enhet
+  list_options:
+    use_tag_color_for_bars: Använd taggfärger
+    use_tag_color_for_bars_tooltip: Visa staplar med färgen från sina taggar istället för sina egna färger

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/tr.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/tr.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Süre
     name: Ad
     device: Cihaz
+  list_options:
+    use_tag_color_for_bars: Etiket renklerini kullan
+    use_tag_color_for_bars_tooltip: Çubukları kendi renkleri yerine etiketlerinin renkleriyle göster

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/uk.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/uk.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: Тривалість
     name: Ім'я
     device: Пристрій
+  list_options:
+    use_tag_color_for_bars: Використовувати кольори тегів
+    use_tag_color_for_bars_tooltip: Показувати смужки кольором їх тегів замість їх власного кольору

--- a/src/lib/presentation/ui/features/app_usages/assets/locales/zh.yaml
+++ b/src/lib/presentation/ui/features/app_usages/assets/locales/zh.yaml
@@ -191,3 +191,6 @@ app_usages:
     duration: 时长
     name: 名称
     device: 设备
+  list_options:
+    use_tag_color_for_bars: 使用标签颜色
+    use_tag_color_for_bars_tooltip: 使用标签的颜色而非其自己的颜色显示条形

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_card.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_card.dart
@@ -34,12 +34,23 @@ class AppUsageCard extends StatelessWidget {
     if (useTagColorForBars && appUsage.tags.isNotEmpty) {
       final firstTag = appUsage.tags.first;
       if (firstTag.tagColor != null) {
-        return AppUsageUiConstants.getTagColor(firstTag.tagColor!);
+        try {
+          return AppUsageUiConstants.getTagColor(firstTag.tagColor!);
+        } catch (e) {
+          // Invalid color format, fall through to the next option.
+        }
       }
     }
 
     // Otherwise use app usage's own color
-    return appUsage.color != null ? AppUsageUiConstants.getTagColor(appUsage.color) : primaryColor;
+    if (appUsage.color != null) {
+      try {
+        return AppUsageUiConstants.getTagColor(appUsage.color!);
+      } catch (e) {
+        // Invalid color format, fall back to primary color.
+      }
+    }
+    return primaryColor;
   }
 
   @override

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_card.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_card.dart
@@ -14,6 +14,7 @@ class AppUsageCard extends StatelessWidget {
   final double maxDurationInListing;
   final double? maxCompareDurationInListing;
   final VoidCallback? onTap;
+  final bool useTagColorForBars;
 
   const AppUsageCard({
     super.key,
@@ -21,14 +22,29 @@ class AppUsageCard extends StatelessWidget {
     required this.maxDurationInListing,
     this.maxCompareDurationInListing,
     this.onTap,
+    this.useTagColorForBars = false,
   });
 
   static final _translationService = container.resolve<ITranslationService>();
 
+  Color _getBarColor(BuildContext context) {
+    final primaryColor = Theme.of(context).primaryColor;
+
+    // If toggle is ON and app usage has tags, use first tag's color
+    if (useTagColorForBars && appUsage.tags.isNotEmpty) {
+      final firstTag = appUsage.tags.first;
+      if (firstTag.tagColor != null) {
+        return AppUsageUiConstants.getTagColor(firstTag.tagColor!);
+      }
+    }
+
+    // Otherwise use app usage's own color
+    return appUsage.color != null ? AppUsageUiConstants.getTagColor(appUsage.color) : primaryColor;
+  }
+
   @override
   Widget build(BuildContext context) {
-    final primaryColor = Theme.of(context).primaryColor;
-    final barColor = appUsage.color != null ? AppUsageUiConstants.getTagColor(appUsage.color) : primaryColor;
+    final barColor = _getBarColor(context);
 
     final duration = appUsage.duration.toDouble() / 60;
     // Use 1.0 as minimum maxDuration to avoid division by zero

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_list.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_list.dart
@@ -50,6 +50,7 @@ class FilterContext {
   final List<String>? filterByDevices;
   final bool showComparison;
   final SortConfig<AppUsageSortFields>? sortConfig;
+  final bool useTagColorForBars;
 
   const FilterContext({
     this.filterByTags,
@@ -59,11 +60,12 @@ class FilterContext {
     this.filterByDevices,
     this.showComparison = false,
     this.sortConfig,
+    this.useTagColorForBars = false,
   });
 
   @override
   String toString() =>
-      'FilterContext(tags: $filterByTags, showNoTags: $showNoTagsFilter, startDate: $filterStartDate, endDate: $filterEndDate, devices: $filterByDevices, showComparison: $showComparison, sortConfig: $sortConfig)';
+      'FilterContext(tags: $filterByTags, showNoTags: $showNoTagsFilter, startDate: $filterStartDate, endDate: $filterEndDate, devices: $filterByDevices, showComparison: $showComparison, sortConfig: $sortConfig, useTagColorForBars: $useTagColorForBars)';
 }
 
 class AppUsageList extends StatefulWidget implements IPaginatedWidget {
@@ -77,6 +79,7 @@ class AppUsageList extends StatefulWidget implements IPaginatedWidget {
   final List<String>? filterByDevices;
   final bool showComparison;
   final SortConfig<AppUsageSortFields>? sortConfig;
+  final bool useTagColorForBars;
 
   @override
   final PaginationMode paginationMode;
@@ -93,6 +96,7 @@ class AppUsageList extends StatefulWidget implements IPaginatedWidget {
     this.filterByDevices,
     this.showComparison = false,
     this.sortConfig,
+    this.useTagColorForBars = false,
     this.paginationMode = PaginationMode.loadMore,
   });
 
@@ -155,6 +159,7 @@ class AppUsageListState extends State<AppUsageList> with PaginationMixin<AppUsag
         filterByDevices: widget.filterByDevices,
         showComparison: widget.showComparison,
         sortConfig: widget.sortConfig,
+        useTagColorForBars: widget.useTagColorForBars,
       );
 
   bool _filtersChanged({required FilterContext oldFilters, required FilterContext newFilters}) {
@@ -166,6 +171,7 @@ class AppUsageListState extends State<AppUsageList> with PaginationMixin<AppUsag
       'filterByDevices': oldFilters.filterByDevices,
       'showComparison': oldFilters.showComparison,
       'sortConfig': oldFilters.sortConfig,
+      'useTagColorForBars': oldFilters.useTagColorForBars,
     };
 
     final newMap = {
@@ -176,6 +182,7 @@ class AppUsageListState extends State<AppUsageList> with PaginationMixin<AppUsag
       'filterByDevices': newFilters.filterByDevices,
       'showComparison': newFilters.showComparison,
       'sortConfig': newFilters.sortConfig,
+      'useTagColorForBars': newFilters.useTagColorForBars,
     };
 
     return CollectionUtils.hasAnyMapValueChanged(oldMap, newMap);
@@ -408,6 +415,7 @@ class AppUsageListState extends State<AppUsageList> with PaginationMixin<AppUsag
                   maxDurationInListing: _maxDuration,
                   maxCompareDurationInListing: _maxCompareDuration,
                   onTap: () => widget.onOpenDetails?.call(item.appUsage.id),
+                  useTagColorForBars: widget.useTagColorForBars,
                 ),
               ),
             _SeparatorItem() => SizedBox(

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_list_options.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_list_options.dart
@@ -33,6 +33,7 @@ class AppUsageFilterState {
   final List<String>? devices;
   final bool showComparison;
   final SortConfig<AppUsageSortFields>? sortConfig;
+  final bool useTagColorForBars;
 
   const AppUsageFilterState({
     this.tags,
@@ -43,6 +44,7 @@ class AppUsageFilterState {
     this.devices,
     this.showComparison = false,
     this.sortConfig,
+    this.useTagColorForBars = false,
   });
 
   AppUsageFilterState copyWith({
@@ -54,6 +56,7 @@ class AppUsageFilterState {
     List<String>? devices,
     bool? showComparison,
     SortConfig<AppUsageSortFields>? sortConfig,
+    bool? useTagColorForBars,
   }) {
     return AppUsageFilterState(
       tags: tags ?? this.tags,
@@ -64,6 +67,7 @@ class AppUsageFilterState {
       devices: devices ?? this.devices,
       showComparison: showComparison ?? this.showComparison,
       sortConfig: sortConfig ?? this.sortConfig,
+      useTagColorForBars: useTagColorForBars ?? this.useTagColorForBars,
     );
   }
 }
@@ -132,6 +136,7 @@ class _AppUsageFiltersState extends PersistentListOptionsBaseState<AppUsageListO
         devices: settings.devices,
         showComparison: settings.showComparison,
         sortConfig: settings.sortConfig,
+        useTagColorForBars: settings.useTagColorForBars,
       );
 
       if (mounted) {
@@ -165,6 +170,7 @@ class _AppUsageFiltersState extends PersistentListOptionsBaseState<AppUsageListO
           devices: _currentState.devices,
           showComparison: _currentState.showComparison,
           sortConfig: _currentState.sortConfig,
+          useTagColorForBars: _currentState.useTagColorForBars,
         );
 
         await filterSettingsManager.saveFilterSettings(
@@ -195,6 +201,7 @@ class _AppUsageFiltersState extends PersistentListOptionsBaseState<AppUsageListO
       devices: _currentState.devices,
       showComparison: _currentState.showComparison,
       sortConfig: _currentState.sortConfig,
+      useTagColorForBars: _currentState.useTagColorForBars,
     );
 
     final hasChanges = await filterSettingsManager.hasUnsavedChanges(
@@ -385,6 +392,23 @@ class _AppUsageFiltersState extends PersistentListOptionsBaseState<AppUsageListO
             onPressed: () {
               final newState = _currentState.copyWith(
                 showComparison: !_currentState.showComparison,
+              );
+              if (mounted) {
+                setState(() => _currentState = newState);
+              }
+              widget.onFiltersChanged(newState);
+              handleFilterChange();
+            },
+          ),
+
+          // Use Tag Color For Bars Toggle
+          IconButton(
+            icon: const Icon(Icons.palette),
+            color: _currentState.useTagColorForBars ? _themeService.primaryColor : Colors.grey,
+            tooltip: _translationService.translate(AppUsageTranslationKeys.useTagColorForBarsTooltip),
+            onPressed: () {
+              final newState = _currentState.copyWith(
+                useTagColorForBars: !_currentState.useTagColorForBars,
               );
               if (mounted) {
                 setState(() => _currentState = newState);

--- a/src/lib/presentation/ui/features/app_usages/constants/app_usage_translation_keys.dart
+++ b/src/lib/presentation/ui/features/app_usages/constants/app_usage_translation_keys.dart
@@ -97,4 +97,8 @@ class AppUsageTranslationKeys extends application.AppUsageTranslationKeys {
   static const String sortDuration = 'app_usages.sort.duration';
   static const String sortName = 'app_usages.sort.name';
   static const String sortDevice = 'app_usages.sort.device';
+
+  // List Options
+  static const String useTagColorForBars = 'app_usages.list_options.use_tag_color_for_bars';
+  static const String useTagColorForBarsTooltip = 'app_usages.list_options.use_tag_color_for_bars_tooltip';
 }

--- a/src/lib/presentation/ui/features/app_usages/models/app_usage_filter_settings.dart
+++ b/src/lib/presentation/ui/features/app_usages/models/app_usage_filter_settings.dart
@@ -27,6 +27,9 @@ class AppUsageFilterSettings {
   /// Current sort configuration
   final SortConfig<AppUsageSortFields>? sortConfig;
 
+  /// Flag to indicate if bar colors should follow tag colors
+  final bool useTagColorForBars;
+
   /// Default constructor
   AppUsageFilterSettings({
     this.tags,
@@ -37,6 +40,7 @@ class AppUsageFilterSettings {
     this.devices,
     this.showComparison = false,
     this.sortConfig,
+    this.useTagColorForBars = false,
   });
 
   /// Create settings from a JSON map
@@ -85,6 +89,7 @@ class AppUsageFilterSettings {
               ),
             )
           : null,
+      useTagColorForBars: json['useTagColorForBars'] as bool? ?? false,
     );
   }
 
@@ -119,6 +124,8 @@ class AppUsageFilterSettings {
       json['sortConfig'] = sortConfig!.toJson((v) => v.toString());
     }
 
+    json['useTagColorForBars'] = useTagColorForBars;
+
     return json;
   }
 
@@ -132,6 +139,7 @@ class AppUsageFilterSettings {
     List<String>? devices,
     bool? showComparison,
     SortConfig<AppUsageSortFields>? sortConfig,
+    bool? useTagColorForBars,
   }) {
     return AppUsageFilterSettings(
       tags: tags ?? this.tags,
@@ -142,6 +150,7 @@ class AppUsageFilterSettings {
       devices: devices ?? this.devices,
       showComparison: showComparison ?? this.showComparison,
       sortConfig: sortConfig ?? this.sortConfig,
+      useTagColorForBars: useTagColorForBars ?? this.useTagColorForBars,
     );
   }
 }

--- a/src/lib/presentation/ui/features/app_usages/pages/app_usage_view_page.dart
+++ b/src/lib/presentation/ui/features/app_usages/pages/app_usage_view_page.dart
@@ -324,6 +324,7 @@ class _AppUsageViewPageState extends State<AppUsageViewPage> {
                       filterByDevices: _filterState.devices,
                       showComparison: _filterState.showComparison,
                       sortConfig: _filterState.sortConfig,
+                      useTagColorForBars: _filterState.useTagColorForBars,
                       paginationMode: PaginationMode.infinityScroll),
                 ),
             ],


### PR DESCRIPTION
### 🚀 Motivation and Context

This PR adds a new option to use tag colors instead of app-specific colors when displaying app usage bars. This provides users with better visual organization, allowing them to quickly identify usage patterns by tag/category rather than by individual app.

### ⚙️ Implementation Details

- Added `useTagColorForBars` boolean option to `AppUsageFilterSettings` model
- Extended `AppUsageListOptions` component with a new toggle switch
- Modified `AppUsageCard` to use tag color when the option is enabled
- Added corresponding translation keys for all 22 supported languages
- Added tooltip to explain the feature to users

Key files modified:
- `app_usage_filter_settings.dart`: Added the filter option
- `app_usage_list_options.dart`: Added UI toggle with tooltip
- `app_usage_card.dart`: Implemented conditional color logic
- `app_usage_view_page.dart`: Wired up the new option
- Locale files: Added translations for `use_tag_color_for_bars` and `use_tag_color_for_bars_tooltip`

### 📋 Checklist for Reviewer

- [ ] Tests passed locally.
- [ ] Commit history is clean and descriptive.
- [ ] Documentation updated (if applicable).
- [ ] Code quality standards were met (e.g., linter passed).

### 🔗 Related

Closes #189 

## Summary by Sourcery

Add a user-configurable option to color app usage bars based on tag colors instead of app-specific colors.

New Features:
- Introduce a useTagColorForBars setting in app usage filters to switch bar colors from app colors to tag colors.
- Add a palette toggle in the app usage list options to enable or disable tag-based bar coloring.
- Apply the selected bar color mode in app usage cards, preferring the first tag color when enabled.
- Localize the new list option label and tooltip across all supported languages.

Enhancements:
- Persist the new bar color preference in AppUsageFilterSettings and propagate it through the app usage list and view page filtering context.