### PR TITLE
fix: add Asian font fallbacks to theme configuration

### DIFF
--- a/src/lib/presentation/ui/shared/constants/app_theme.dart
+++ b/src/lib/presentation/ui/shared/constants/app_theme.dart
@@ -35,6 +35,13 @@ class AppTheme {
     'FangSong',
     'Malgun Gothic',
     'Meiryo',
+
+    // macOS
+    'PingFang SC',
+    'PingFang TC',
+    'Hiragino Sans GB',
+    'Heiti SC',
+
     // Linux
     'Noto Sans CJK SC',
     'Noto Sans CJK TC',
@@ -42,6 +49,7 @@ class AppTheme {
     'Noto Sans CJK KR',
     'WenQuanYi Micro Hei',
     'Droid Sans Fallback',
+
     // General
     'sans-serif',
   ];

--- a/src/lib/presentation/ui/shared/constants/app_theme.dart
+++ b/src/lib/presentation/ui/shared/constants/app_theme.dart
@@ -27,6 +27,25 @@ class AppTheme {
     _themeService = null;
   }
 
+  static const List<String> fontFamilyFallback = [
+    // Windows
+    'Microsoft YaHei',
+    'SimHei',
+    'KaiTi',
+    'FangSong',
+    'Malgun Gothic',
+    'Meiryo',
+    // Linux
+    'Noto Sans CJK SC',
+    'Noto Sans CJK TC',
+    'Noto Sans CJK JP',
+    'Noto Sans CJK KR',
+    'WenQuanYi Micro Hei',
+    'Droid Sans Fallback',
+    // General
+    'sans-serif',
+  ];
+
   // Dynamic Colors (get from theme service)
   static Color get primaryColor => _service.primaryColor;
   static Color get surface0 => _service.surface0;

--- a/src/lib/presentation/ui/shared/services/theme_service/theme_data_builder.dart
+++ b/src/lib/presentation/ui/shared/services/theme_service/theme_data_builder.dart
@@ -40,6 +40,7 @@ class ThemeDataBuilder {
       brightness: isDark ? Brightness.dark : Brightness.light,
       colorScheme: colorScheme,
       primaryColor: primaryColor,
+      fontFamilyFallback: AppTheme.fontFamilyFallback,
       scaffoldBackgroundColor: surface0,
       canvasColor: surface0,
       cardColor: surface2,

--- a/src/test/presentation/ui/shared/services/theme_service/font_fallback_test.dart
+++ b/src/test/presentation/ui/shared/services/theme_service/font_fallback_test.dart
@@ -4,7 +4,7 @@ import 'package:whph/presentation/ui/shared/services/theme_service/theme_data_bu
 import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
 
 void main() {
-  test('ThemeDataBuilder includes fontFamilyFallback', () {
+  test('ThemeDataBuilder applies fontFamilyFallback to TextTheme', () {
     const builder = ThemeDataBuilder(
       isDark: false,
       primaryColor: Colors.blue,
@@ -21,9 +21,13 @@ void main() {
     );
 
     final themeData = builder.build(const ColorScheme.light());
+    final fallback = themeData.textTheme.bodyLarge?.fontFamilyFallback;
 
-    expect(themeData.textTheme.bodyLarge?.fontFamilyFallback, AppTheme.fontFamilyFallback);
-    expect(themeData.textTheme.bodyLarge?.fontFamilyFallback, contains('Microsoft YaHei'));
-    expect(themeData.textTheme.bodyLarge?.fontFamilyFallback, contains('Noto Sans CJK SC'));
+    expect(fallback, AppTheme.fontFamilyFallback);
+
+    // Check key fonts for each platform
+    expect(fallback, contains('Microsoft YaHei')); // Windows
+    expect(fallback, contains('PingFang SC')); // macOS
+    expect(fallback, contains('Noto Sans CJK SC')); // Linux
   });
 }

--- a/src/test/presentation/ui/shared/services/theme_service/font_fallback_test.dart
+++ b/src/test/presentation/ui/shared/services/theme_service/font_fallback_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:whph/presentation/ui/shared/services/theme_service/theme_data_builder.dart';
+import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
+
+void main() {
+  test('ThemeDataBuilder includes fontFamilyFallback', () {
+    const builder = ThemeDataBuilder(
+      isDark: false,
+      primaryColor: Colors.blue,
+      densityMultiplier: 1.0,
+      surface0: Colors.white,
+      surface1: Colors.white,
+      surface2: Colors.white,
+      surface3: Colors.white,
+      textColor: Colors.black,
+      secondaryTextColor: Colors.grey,
+      lightTextColor: Colors.white,
+      dividerColor: Colors.grey,
+      barrierColor: Colors.black54,
+    );
+
+    final themeData = builder.build(const ColorScheme.light());
+
+    expect(themeData.textTheme.bodyLarge?.fontFamilyFallback, AppTheme.fontFamilyFallback);
+    expect(themeData.textTheme.bodyLarge?.fontFamilyFallback, contains('Microsoft YaHei'));
+    expect(themeData.textTheme.bodyLarge?.fontFamilyFallback, contains('Noto Sans CJK SC'));
+  });
+}


### PR DESCRIPTION
Fixes #224 by adding a comprehensive font fallback list for CJK characters in the presentation layer theme configuration.

## Summary by Sourcery

Add centralized Asian font fallback configuration to the app theme and wire it into theme creation to improve CJK text rendering.

New Features:
- Introduce a shared fontFamilyFallback list in the app theme covering common CJK fonts across platforms.

Tests:
- Add a theme service test to verify ThemeDataBuilder applies the configured fontFamilyFallback to text themes.