### PR TITLE
fix: move translatable flag determination to application layer

### DIFF
--- a/src/lib/core/application/features/habits/models/habit_list_item.dart
+++ b/src/lib/core/application/features/habits/models/habit_list_item.dart
@@ -18,6 +18,7 @@ class HabitListItem {
   final int targetFrequency;
   final int periodDays;
   final String? groupName;
+  final bool isGroupNameTranslatable;
 
   const HabitListItem({
     required this.id,
@@ -37,6 +38,7 @@ class HabitListItem {
     this.targetFrequency = 1,
     this.periodDays = 1,
     this.groupName,
+    this.isGroupNameTranslatable = false,
   });
 
   bool get isArchived => archivedDate != null;
@@ -59,6 +61,7 @@ class HabitListItem {
     int? targetFrequency,
     int? periodDays,
     String? groupName,
+    bool? isGroupNameTranslatable,
   }) {
     return HabitListItem(
       id: id ?? this.id,
@@ -78,6 +81,7 @@ class HabitListItem {
       targetFrequency: targetFrequency ?? this.targetFrequency,
       periodDays: periodDays ?? this.periodDays,
       groupName: groupName ?? this.groupName,
+      isGroupNameTranslatable: isGroupNameTranslatable ?? this.isGroupNameTranslatable,
     );
   }
 }

--- a/src/lib/core/application/features/habits/queries/get_list_habits_query.dart
+++ b/src/lib/core/application/features/habits/queries/get_list_habits_query.dart
@@ -123,11 +123,12 @@ class GetListHabitsQueryHandler implements IRequestHandler<GetListHabitsQuery, G
       }
 
       // Assign group name
-      final groupName = HabitGroupingHelper.getGroupName(habitItem.copyWith(tags: tags), primarySortField);
+      final groupInfo = HabitGroupingHelper.getGroupInfo(habitItem.copyWith(tags: tags), primarySortField);
 
       return habitItem.copyWith(
         tags: tags,
-        groupName: groupName,
+        groupName: groupInfo?.name,
+        isGroupNameTranslatable: groupInfo?.isTranslatable ?? false,
       );
     }).toList();
 

--- a/src/lib/core/application/features/habits/utils/habit_grouping_helper.dart
+++ b/src/lib/core/application/features/habits/utils/habit_grouping_helper.dart
@@ -2,25 +2,39 @@ import 'package:whph/core/application/features/habits/models/habit_sort_fields.d
 import 'package:whph/core/application/features/habits/queries/get_list_habits_query.dart';
 import 'package:whph/core/application/shared/utils/grouping_utils.dart';
 
+class HabitGroupInfo {
+  final String? name;
+  final bool isTranslatable;
+
+  const HabitGroupInfo({this.name, this.isTranslatable = false});
+}
+
 class HabitGroupingHelper {
   static String? getGroupName(HabitListItem habit, HabitSortFields? sortField, {DateTime? now}) {
+    return getGroupInfo(habit, sortField, now: now)?.name;
+  }
+
+  static HabitGroupInfo? getGroupInfo(HabitListItem habit, HabitSortFields? sortField, {DateTime? now}) {
     if (sortField == null) return null;
 
     switch (sortField) {
       case HabitSortFields.name:
-        return GroupingUtils.getTitleGroup(habit.name);
+        return HabitGroupInfo(name: GroupingUtils.getTitleGroup(habit.name), isTranslatable: false);
       case HabitSortFields.createdDate:
-        return GroupingUtils.getBackwardDateGroup(habit.createdDate, now: now);
+        return HabitGroupInfo(
+            name: GroupingUtils.getBackwardDateGroup(habit.createdDate, now: now), isTranslatable: true);
       case HabitSortFields.modifiedDate:
-        return GroupingUtils.getBackwardDateGroup(habit.modifiedDate, now: now);
+        return HabitGroupInfo(
+            name: GroupingUtils.getBackwardDateGroup(habit.modifiedDate, now: now), isTranslatable: true);
       case HabitSortFields.estimatedTime:
-        return GroupingUtils.getDurationGroup(habit.estimatedTime);
+        return HabitGroupInfo(name: GroupingUtils.getDurationGroup(habit.estimatedTime), isTranslatable: true);
       case HabitSortFields.actualTime:
-        return GroupingUtils.getDurationGroup(habit.actualTime); // actualTime is in minutes
+        return HabitGroupInfo(name: GroupingUtils.getDurationGroup(habit.actualTime), isTranslatable: true);
       case HabitSortFields.archivedDate:
-        return GroupingUtils.getBackwardDateGroup(habit.archivedDate, now: now);
+        return HabitGroupInfo(
+            name: GroupingUtils.getBackwardDateGroup(habit.archivedDate, now: now), isTranslatable: true);
       case HabitSortFields.tag:
-        return GroupingUtils.getTagGroup(habit.tags);
+        return HabitGroupInfo(name: GroupingUtils.getTagGroup(habit.tags), isTranslatable: false);
     }
   }
 }

--- a/src/lib/core/application/features/tasks/models/task_list_item.dart
+++ b/src/lib/core/application/features/tasks/models/task_list_item.dart
@@ -20,6 +20,7 @@ class TaskListItem {
   final ReminderTime plannedDateReminderTime;
   final ReminderTime deadlineDateReminderTime;
   final String? groupName;
+  final bool isGroupNameTranslatable;
 
   TaskListItem({
     required this.id,
@@ -40,6 +41,7 @@ class TaskListItem {
     this.plannedDateReminderTime = ReminderTime.none,
     this.deadlineDateReminderTime = ReminderTime.none,
     this.groupName,
+    this.isGroupNameTranslatable = false,
   });
 
   TaskListItem copyWith({
@@ -61,6 +63,7 @@ class TaskListItem {
     ReminderTime? plannedDateReminderTime,
     ReminderTime? deadlineDateReminderTime,
     String? groupName,
+    bool? isGroupNameTranslatable,
   }) {
     return TaskListItem(
       id: id ?? this.id,
@@ -81,6 +84,7 @@ class TaskListItem {
       plannedDateReminderTime: plannedDateReminderTime ?? this.plannedDateReminderTime,
       deadlineDateReminderTime: deadlineDateReminderTime ?? this.deadlineDateReminderTime,
       groupName: groupName ?? this.groupName,
+      isGroupNameTranslatable: isGroupNameTranslatable ?? this.isGroupNameTranslatable,
     );
   }
 }

--- a/src/lib/core/application/features/tasks/queries/get_list_tasks_query.dart
+++ b/src/lib/core/application/features/tasks/queries/get_list_tasks_query.dart
@@ -170,8 +170,8 @@ class GetListTasksQueryHandler implements IRequestHandler<GetListTasksQuery, Get
 
     // Set isGroupNameTranslatable on each task
     final itemsWithTranslatableFlag = tasks.items.map((task) {
-      if (task.groupName != null) {
-        return task.copyWith(isGroupNameTranslatable: isGroupTranslatable);
+      if (task.groupName != null && isGroupTranslatable) {
+        return task.copyWith(isGroupNameTranslatable: true);
       }
       return task;
     }).toList();

--- a/src/lib/core/application/features/tasks/queries/get_list_tasks_query.dart
+++ b/src/lib/core/application/features/tasks/queries/get_list_tasks_query.dart
@@ -2,6 +2,7 @@ import 'package:whph/core/application/features/tasks/models/task_list_item.dart'
 import 'package:mediatr/mediatr.dart';
 import 'package:whph/core/application/features/tasks/models/task_query_filter.dart';
 import 'package:whph/core/application/features/tasks/services/abstraction/i_task_repository.dart';
+import 'package:whph/core/application/features/tasks/utils/task_grouping_helper.dart';
 import 'package:acore/acore.dart';
 
 import 'package:whph/core/application/features/tasks/models/task_sort_fields.dart';
@@ -161,8 +162,22 @@ class GetListTasksQueryHandler implements IRequestHandler<GetListTasksQuery, Get
       ),
     );
 
+    // Determine if group names should be translated based on sort field
+    final groupField = request.enableGrouping
+        ? request.groupBy ?? (request.sortBy?.isNotEmpty == true ? request.sortBy!.first : null)
+        : null;
+    final isGroupTranslatable = TaskGroupingHelper.isGroupTranslatable(groupField?.field);
+
+    // Set isGroupNameTranslatable on each task
+    final itemsWithTranslatableFlag = tasks.items.map((task) {
+      if (task.groupName != null) {
+        return task.copyWith(isGroupNameTranslatable: isGroupTranslatable);
+      }
+      return task;
+    }).toList();
+
     return GetListTasksQueryResponse(
-      items: tasks.items,
+      items: itemsWithTranslatableFlag,
       totalItemCount: tasks.totalItemCount,
       pageIndex: request.pageIndex,
       pageSize: request.pageSize,

--- a/src/lib/core/application/features/tasks/utils/task_grouping_helper.dart
+++ b/src/lib/core/application/features/tasks/utils/task_grouping_helper.dart
@@ -31,6 +31,25 @@ class TaskGroupingHelper {
     }
   }
 
+  /// Returns true if the group name should be translated based on the sort field
+  static bool isGroupTranslatable(TaskSortFields? sortField) {
+    if (sortField == null) return false;
+
+    switch (sortField) {
+      case TaskSortFields.priority:
+      case TaskSortFields.createdDate:
+      case TaskSortFields.deadlineDate:
+      case TaskSortFields.modifiedDate:
+      case TaskSortFields.plannedDate:
+      case TaskSortFields.estimatedTime:
+      case TaskSortFields.totalDuration:
+        return true;
+      case TaskSortFields.title:
+      case TaskSortFields.tag:
+        return false;
+    }
+  }
+
   static String _getPriorityGroup(EisenhowerPriority? priority) {
     if (priority == null) return SharedTranslationKeys.none;
 

--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_list.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_list.dart
@@ -25,13 +25,13 @@ import 'package:whph/presentation/ui/shared/mixins/list_group_collapse_mixin.dar
 sealed class _ListItem {}
 
 class _HeaderItem extends _ListItem {
-  final String title;
-  final bool shouldTranslate;
+  final String id;
+  final String displayTitle;
   final int index;
   final bool isExpanded;
   _HeaderItem({
-    required this.title,
-    required this.shouldTranslate,
+    required this.id,
+    required this.displayTitle,
     required this.index,
     required this.isExpanded,
   });
@@ -368,8 +368,10 @@ class AppUsageListState extends State<AppUsageList>
           ));
         }
         items.add(_HeaderItem(
-          title: appUsage.groupName!,
-          shouldTranslate: appUsage.isGroupNameTranslatable,
+          id: appUsage.groupName!,
+          displayTitle: appUsage.isGroupNameTranslatable
+              ? _translationService.translate(appUsage.groupName!)
+              : appUsage.groupName!,
           index: i,
           isExpanded: !collapsedGroups.contains(appUsage.groupName),
         ));
@@ -423,11 +425,10 @@ class AppUsageListState extends State<AppUsageList>
           final item = _flattenedItems[index];
           return switch (item) {
             _HeaderItem() => ListGroupHeader(
-                key: ValueKey('header_${item.title}_${item.index}'),
-                title: item.title,
-                shouldTranslate: item.shouldTranslate,
+                key: ValueKey('header_${item.id}_${item.index}'),
+                title: item.displayTitle,
                 isExpanded: item.isExpanded,
-                onTap: () => toggleGroupCollapse(item.title),
+                onTap: () => toggleGroupCollapse(item.id),
               ),
             _DataItem() => Padding(
                 key: ValueKey('app_usage_${item.appUsage.id}'),

--- a/src/lib/presentation/ui/features/habits/components/habits_list.dart
+++ b/src/lib/presentation/ui/features/habits/components/habits_list.dart
@@ -543,32 +543,12 @@ class HabitsListState extends State<HabitsList> with PaginationMixin<HabitsList>
 
   /// Returns a map of group name to whether it should be translated
   Map<String, bool> _getGroupTranslatableMap() {
-    final primarySortField =
-        widget.sortConfig?.groupOption?.field ?? widget.sortConfig?.orderOptions.firstOrNull?.field;
-
-    bool isTranslatable = false;
-    if (primarySortField != null) {
-      switch (primarySortField) {
-        case HabitSortFields.createdDate:
-        case HabitSortFields.modifiedDate:
-        case HabitSortFields.estimatedTime:
-        case HabitSortFields.actualTime:
-        case HabitSortFields.archivedDate:
-          isTranslatable = true;
-          break;
-        case HabitSortFields.name:
-        case HabitSortFields.tag:
-          isTranslatable = false;
-          break;
-      }
-    }
-
-    // Get all unique group names and set the same translatable flag for all
     if (_cachedGroupedHabits == null) return {};
     final groupTranslatable = <String, bool>{};
-    for (final key in _cachedGroupedHabits!.keys) {
-      if (key.isNotEmpty) {
-        groupTranslatable[key] = isTranslatable;
+    for (final entry in _cachedGroupedHabits!.entries) {
+      if (entry.key.isNotEmpty) {
+        // All items in a group share the same translatable property, so we can check the first one.
+        groupTranslatable[entry.key] = entry.value.isNotEmpty ? entry.value.first.isGroupNameTranslatable : false;
       }
     }
     return groupTranslatable;

--- a/src/lib/presentation/ui/features/habits/components/habits_list.dart
+++ b/src/lib/presentation/ui/features/habits/components/habits_list.dart
@@ -544,14 +544,10 @@ class HabitsListState extends State<HabitsList> with PaginationMixin<HabitsList>
   /// Returns a map of group name to whether it should be translated
   Map<String, bool> _getGroupTranslatableMap() {
     if (_cachedGroupedHabits == null) return {};
-    final groupTranslatable = <String, bool>{};
-    for (final entry in _cachedGroupedHabits!.entries) {
-      if (entry.key.isNotEmpty) {
-        // All items in a group share the same translatable property, so we can check the first one.
-        groupTranslatable[entry.key] = entry.value.isNotEmpty ? entry.value.first.isGroupNameTranslatable : false;
-      }
-    }
-    return groupTranslatable;
+    return {
+      for (final entry in _cachedGroupedHabits!.entries)
+        if (entry.key.isNotEmpty) entry.key: entry.value.isNotEmpty ? entry.value.first.isGroupNameTranslatable : false,
+    };
   }
 
   Future<void> _onReorderInGroup(int oldIndex, int targetIndex, List<HabitListItem> groupHabits) async {

--- a/src/lib/presentation/ui/features/notes/components/notes_list.dart
+++ b/src/lib/presentation/ui/features/notes/components/notes_list.dart
@@ -301,8 +301,7 @@ class NotesListState extends State<NotesList> with PaginationMixin<NotesList>, L
         }
         listItems.add(ListGroupHeader(
           key: ValueKey('header_${note.groupName}'),
-          title: note.groupName!,
-          shouldTranslate: note.isGroupNameTranslatable,
+          title: note.isGroupNameTranslatable ? _translationService.translate(note.groupName!) : note.groupName!,
           isExpanded: !collapsedGroups.contains(note.groupName),
           onTap: () => toggleGroupCollapse(note.groupName!),
         ));

--- a/src/lib/presentation/ui/features/tags/components/tag_select_dialog.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_select_dialog.dart
@@ -317,7 +317,6 @@ class _TagSelectDialogState extends State<TagSelectDialog> {
                       return ListGroupHeader(
                         key: ValueKey('header_${item.id}'),
                         title: item.headerText!,
-                        shouldTranslate: false,
                         isExpanded: !item.isCollapsed,
                         onTap: () => _toggleGroupCollapse(item.id!),
                       );

--- a/src/lib/presentation/ui/features/tags/components/tags_list.dart
+++ b/src/lib/presentation/ui/features/tags/components/tags_list.dart
@@ -236,8 +236,7 @@ class TagsListState extends State<TagsList> with PaginationMixin<TagsList>, List
         }
         listItems.add(ListGroupHeader(
           key: ValueKey('header_${tag.groupName}_$i'),
-          title: tag.groupName!,
-          shouldTranslate: tag.isGroupNameTranslatable,
+          title: tag.isGroupNameTranslatable ? _translationService.translate(tag.groupName!) : tag.groupName!,
           isExpanded: !collapsedGroups.contains(tag.groupName),
           onTap: () => toggleGroupCollapse(tag.groupName!),
         ));

--- a/src/lib/presentation/ui/features/tasks/components/tasks_list.dart
+++ b/src/lib/presentation/ui/features/tasks/components/tasks_list.dart
@@ -560,34 +560,12 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList>, List
 
   /// Returns a map of group name to whether it should be translated
   Map<String, bool> _getGroupTranslatableMap() {
-    final primarySortField =
-        widget.sortConfig?.groupOption?.field ?? widget.sortConfig?.orderOptions.firstOrNull?.field;
-
-    bool isTranslatable = false;
-    if (primarySortField != null) {
-      switch (primarySortField) {
-        case TaskSortFields.priority:
-        case TaskSortFields.createdDate:
-        case TaskSortFields.deadlineDate:
-        case TaskSortFields.modifiedDate:
-        case TaskSortFields.plannedDate:
-        case TaskSortFields.estimatedTime:
-        case TaskSortFields.totalDuration:
-          isTranslatable = true;
-          break;
-        case TaskSortFields.title:
-        case TaskSortFields.tag:
-          isTranslatable = false;
-          break;
-      }
-    }
-
-    // Get all unique group names and set the same translatable flag for all
     if (_cachedGroupedTasks == null) return {};
     final groupTranslatable = <String, bool>{};
-    for (final key in _cachedGroupedTasks!.keys) {
-      if (key.isNotEmpty) {
-        groupTranslatable[key] = isTranslatable;
+    for (final entry in _cachedGroupedTasks!.entries) {
+      if (entry.key.isNotEmpty) {
+        // All items in a group share the same translatable property, so we can check the first one.
+        groupTranslatable[entry.key] = entry.value.isNotEmpty ? entry.value.first.isGroupNameTranslatable : false;
       }
     }
     return groupTranslatable;

--- a/src/lib/presentation/ui/features/tasks/components/tasks_list.dart
+++ b/src/lib/presentation/ui/features/tasks/components/tasks_list.dart
@@ -561,14 +561,10 @@ class TaskListState extends State<TaskList> with PaginationMixin<TaskList>, List
   /// Returns a map of group name to whether it should be translated
   Map<String, bool> _getGroupTranslatableMap() {
     if (_cachedGroupedTasks == null) return {};
-    final groupTranslatable = <String, bool>{};
-    for (final entry in _cachedGroupedTasks!.entries) {
-      if (entry.key.isNotEmpty) {
-        // All items in a group share the same translatable property, so we can check the first one.
-        groupTranslatable[entry.key] = entry.value.isNotEmpty ? entry.value.first.isGroupNameTranslatable : false;
-      }
-    }
-    return groupTranslatable;
+    return {
+      for (final entry in _cachedGroupedTasks!.entries)
+        if (entry.key.isNotEmpty) entry.key: entry.value.isNotEmpty ? entry.value.first.isGroupNameTranslatable : false,
+    };
   }
 
   Future<void> _onReorderInGroup(int oldIndex, int targetIndex, List<TaskListItem> groupTasks) async {

--- a/src/lib/presentation/ui/shared/components/list_group_header.dart
+++ b/src/lib/presentation/ui/shared/components/list_group_header.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:whph/presentation/ui/shared/components/section_header.dart';
 import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
-import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
-import 'package:whph/main.dart';
 
 class ListGroupHeader extends StatelessWidget {
   final String title;
-  final bool shouldTranslate;
   final Widget? actions;
   final VoidCallback? onTap;
   final bool isExpanded;
@@ -14,7 +11,6 @@ class ListGroupHeader extends StatelessWidget {
   const ListGroupHeader({
     super.key,
     required this.title,
-    this.shouldTranslate = true,
     this.actions,
     this.onTap,
     this.isExpanded = true,
@@ -22,19 +18,8 @@ class ListGroupHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    String displayTitle = title;
-
-    if (shouldTranslate) {
-      final translationService = container.resolve<ITranslationService>();
-      // Attempt to translate the title if it's a key, otherwise show as is
-      final translated = translationService.translate(title);
-      if (translated.isNotEmpty && translated != title) {
-        displayTitle = translated;
-      }
-    }
-
     Widget header = SectionHeader(
-      title: displayTitle,
+      title: title,
       trailing: Row(
         children: [
           const Expanded(child: Divider()),

--- a/src/lib/presentation/ui/shared/models/visual_item.dart
+++ b/src/lib/presentation/ui/shared/models/visual_item.dart
@@ -7,8 +7,9 @@ sealed class VisualItem<T> {
 /// A header visual item.
 class VisualItemHeader<T> extends VisualItem<T> {
   final String title;
+  final bool isTranslatable;
 
-  const VisualItemHeader(this.title);
+  const VisualItemHeader(this.title, {this.isTranslatable = false});
 }
 
 /// A single data item visual item.

--- a/src/lib/presentation/ui/shared/utils/visual_item_utils.dart
+++ b/src/lib/presentation/ui/shared/utils/visual_item_utils.dart
@@ -4,9 +4,11 @@ class VisualItemUtils {
   /// Transforms a grouped map of items into a flattened list of [VisualItem]s.
   ///
   /// [gridColumns]: If > 1, single items within groups will be chunked into [VisualItemRow]s.
+  /// [groupTranslatable]: A map from group name to whether the group name should be translated.
   static List<VisualItem<T>> getVisualItems<T>({
     required Map<String, List<T>> groupedItems,
     int gridColumns = 1,
+    Map<String, bool>? groupTranslatable,
   }) {
     final List<VisualItem<T>> visualItems = [];
     if (groupedItems.isEmpty) return visualItems;
@@ -14,7 +16,8 @@ class VisualItemUtils {
     for (final entry in groupedItems.entries) {
       // Add header if group name is not empty
       if (entry.key.isNotEmpty) {
-        visualItems.add(VisualItemHeader<T>(entry.key));
+        final isTranslatable = groupTranslatable?[entry.key] ?? false;
+        visualItems.add(VisualItemHeader<T>(entry.key, isTranslatable: isTranslatable));
       }
 
       final items = entry.value;


### PR DESCRIPTION
### 🚀 Motivation and Context

This fix addresses a critical issue with translation handling where group names were incorrectly being treated as translation keys. The previous implementation used a flawed length-based check (`groupName.length <= 15`) that incorrectly labeled user-provided data like "Work", "Personal", and "Learning" as translatable, while priority/date/duration groups needed proper translation support.

### ⚙️ Implementation Details

The refactoring moves translatable flag determination from the presentation layer (UI components) to the application layer (query handlers) following Clean Architecture principles:

- **Removed**: `shouldTranslate` from `ListGroupHeader` component
- **Added**: `isGroupNameTranslatable` field to `HabitListItem` and `TaskListItem` models
- **Moved**: Translatable logic from infrastructure to application layer in `GetListHabitsQuery` and `GetListTasksQuery`
- **Added**: `TaskGroupingHelper.isGroupTranslatable()` and `HabitGroupingHelper.getGroupInfo()` helper methods
- **Updated**: All UI components to use the `isGroupNameTranslatable` flag
- **Enhanced**: `VisualItemHeader` and `VisualItemUtils` to support translatable flag propagation

This ensures that:
- User-defined group names (tags, folders, etc.) are never translated
- System groups (Priorities, Dates, Durations) are always translated
- Translation logic is centralized in the application layer
- Presentation layer receives clear translatable flags from business logic

### 📋 Checklist for Reviewer

- [x] Tests skipped (explicitly requested)
- [x] Commit history is clean and descriptive (Conventional Commits)
- [x] Code quality standards were met
- [x] No merge conflicts detected
- [ ] Documentation updated (if applicable)

### 🔗 Related

N/A