### PR TITLE
fix(sync): prefer gateway-backed LAN interfaces on Windows

### DIFF
--- a/src/lib/core/application/features/sync/services/abstraction/i_network_interface_service.dart
+++ b/src/lib/core/application/features/sync/services/abstraction/i_network_interface_service.dart
@@ -53,8 +53,12 @@ class NetworkInterfaceInfo {
       other is NetworkInterfaceInfo &&
           runtimeType == other.runtimeType &&
           name == other.name &&
-          ipAddress == other.ipAddress;
+          ipAddress == other.ipAddress &&
+          hasDefaultGateway == other.hasDefaultGateway &&
+          interfaceMetric == other.interfaceMetric &&
+          isVirtual == other.isVirtual &&
+          gatewayIp == other.gatewayIp;
 
   @override
-  int get hashCode => Object.hash(name, ipAddress);
+  int get hashCode => Object.hash(name, ipAddress, hasDefaultGateway, interfaceMetric, isVirtual, gatewayIp);
 }

--- a/src/lib/core/application/features/sync/services/abstraction/i_network_interface_service.dart
+++ b/src/lib/core/application/features/sync/services/abstraction/i_network_interface_service.dart
@@ -25,6 +25,10 @@ class NetworkInterfaceInfo {
   final bool isWiFi;
   final bool isEthernet;
   final int priority; // Higher number = higher priority
+  final bool hasDefaultGateway;
+  final int? interfaceMetric;
+  final bool isVirtual;
+  final String? gatewayIp;
 
   const NetworkInterfaceInfo({
     required this.name,
@@ -33,11 +37,15 @@ class NetworkInterfaceInfo {
     required this.isWiFi,
     required this.isEthernet,
     required this.priority,
+    this.hasDefaultGateway = false,
+    this.interfaceMetric,
+    this.isVirtual = false,
+    this.gatewayIp,
   });
 
   @override
   String toString() =>
-      'NetworkInterfaceInfo(name: $name, ip: $ipAddress, wifi: $isWiFi, ethernet: $isEthernet, priority: $priority)';
+      'NetworkInterfaceInfo(name: $name, ip: $ipAddress, wifi: $isWiFi, ethernet: $isEthernet, priority: $priority, hasGateway: $hasDefaultGateway, metric: $interfaceMetric, isVirtual: $isVirtual)';
 
   @override
   bool operator ==(Object other) =>

--- a/src/lib/presentation/ui/features/sync/components/sync_connect_info_dialog.dart
+++ b/src/lib/presentation/ui/features/sync/components/sync_connect_info_dialog.dart
@@ -39,6 +39,7 @@ class _SyncConnectInfoDialogState extends State<SyncConnectInfoDialog> {
   final _deviceIdService = container.resolve<IDeviceIdService>();
 
   String? _ipAddress;
+  List<String> _ipAddresses = const [];
   String? _deviceName;
   String? _deviceId;
   String? _platform;
@@ -61,7 +62,8 @@ class _SyncConnectInfoDialogState extends State<SyncConnectInfoDialog> {
       });
 
       // Get device information
-      _ipAddress = await NetworkUtils.getLocalIpAddress();
+      _ipAddresses = await NetworkUtils.getLocalIpAddresses();
+      _ipAddress = _ipAddresses.isNotEmpty ? _ipAddresses.first : null;
       _deviceName = await DeviceInfoHelper.getDeviceName();
       _deviceId = await _deviceIdService.getDeviceId();
 
@@ -82,6 +84,7 @@ class _SyncConnectInfoDialogState extends State<SyncConnectInfoDialog> {
         deviceName: _deviceName!,
         deviceId: _deviceId!,
         platform: _platform!,
+        ipAddresses: _ipAddresses.isEmpty ? null : _ipAddresses,
       );
 
       Logger.debug('Sync QR Code Message: ${syncQrCodeMessage.toCsv()}');

--- a/src/lib/presentation/ui/shared/utils/network_utils.dart
+++ b/src/lib/presentation/ui/shared/utils/network_utils.dart
@@ -21,7 +21,7 @@ class NetworkUtils {
   static Future<List<String>> getLocalIpAddresses() async {
     try {
       final networkService = container.resolve<INetworkInterfaceService>();
-      return await networkService.getLocalIPAddresses();
+      return await networkService.getPreferredIPAddresses();
     } catch (e) {
       Logger.error('Failed to get local IP addresses via service: $e');
       return [];


### PR DESCRIPTION
## Summary

Fixes Windows sync server address selection where WHPH could advertise a Hyper-V/virtual adapter IP (e.g. `172.31.x.x`) instead of a LAN-reachable adapter.

This change makes interface selection route-aware and gateway-aware so pairing details prefer adapters that are actually reachable from the local network.

Closes #246.

## What Changed

- Extended `NetworkInterfaceInfo` with metadata used for smarter ranking:
  - `hasDefaultGateway`
  - `interfaceMetric`
  - `isVirtual`
  - `gatewayIp`
- Added Windows interface metadata enrichment in `NetworkInterfaceService`:
  - queries PowerShell (`Get-NetIPConfiguration`, `Get-NetIPInterface`)
  - parses gateway + metric info
  - safely falls back to existing behavior if unavailable
- Replaced interface priority logic with route-aware scoring:
  - strongly prefers default-gateway interfaces
  - prefers lower interface metric
  - keeps physical Ethernet/Wi-Fi preference
  - penalizes virtual adapters without default gateway
- Updated primary IP retrieval path to use preferred ordering:
  - `NetworkUtils.getLocalIpAddresses()` now delegates to `getPreferredIPAddresses()`
- Improved connection info robustness:
  - QR payload now includes all preferred local IPs while preserving best-ranked primary IP
- Added tests for:
  - virtual-vs-physical ordering
  - gateway-backed `172.x` handling
  - Windows metadata parsing

## Validation

- `fvm flutter test test/core/application/features/sync/services/network_interface_service_test.dart`
- `fvm flutter analyze lib/core/application/features/sync/services/network_interface_service.dart lib/core/application/features/sync/services/abstraction/i_network_interface_service.dart lib/presentation/ui/shared/utils/network_utils.dart lib/presentation/ui/features/sync/components/sync_connect_info_dialog.dart`

