### PR TITLE
fix(settings): prevent windows crash on opening settings

### DIFF
--- a/src/lib/infrastructure/desktop/settings/desktop_startup_settings_service.dart
+++ b/src/lib/infrastructure/desktop/settings/desktop_startup_settings_service.dart
@@ -11,17 +11,27 @@ import 'package:whph/core/domain/features/settings/setting.dart';
 class DesktopStartupSettingsService implements IStartupSettingsService {
   final ISettingRepository _settingRepository;
 
-  DesktopStartupSettingsService(this._settingRepository) {
-    launchAtStartup.setup(
-      appPath: Platform.resolvedExecutable,
-      appName: AppInfo.name,
-      args: [AppArgs.minimized],
-    );
+  DesktopStartupSettingsService(this._settingRepository);
+
+  Future<void> _ensureSetup() async {
+    if (!Platform.isWindows) return;
+
+    try {
+      launchAtStartup.setup(
+        appPath: Platform.resolvedExecutable,
+        appName: AppInfo.name,
+        args: [AppArgs.minimized],
+      );
+    } catch (e) {
+      // Ignore setup errors, startup functionality will be unavailable but app won't crash
+    }
   }
 
   @override
   Future<void> ensureStartupSettingSync() async {
-    final setting = await _settingRepository.getByKey(SettingKeys.startAtStartup);
+    await _ensureSetup();
+    final setting =
+        await _settingRepository.getByKey(SettingKeys.startAtStartup);
     final shouldStart = setting?.value == 'true';
     final isEnabled = await launchAtStartup.isEnabled();
 
@@ -34,18 +44,21 @@ class DesktopStartupSettingsService implements IStartupSettingsService {
 
   @override
   Future<bool> isEnabledAtStartup() async {
-    final setting = await _settingRepository.getByKey(SettingKeys.startAtStartup);
+    final setting =
+        await _settingRepository.getByKey(SettingKeys.startAtStartup);
     return setting?.value == 'true';
   }
 
   @override
   Future<void> enableStartAtStartup() async {
+    await _ensureSetup();
     await launchAtStartup.enable();
     await _saveSetting(true);
   }
 
   Future<void> _saveSetting(bool isActive) async {
-    final existingSetting = await _settingRepository.getByKey(SettingKeys.startAtStartup);
+    final existingSetting =
+        await _settingRepository.getByKey(SettingKeys.startAtStartup);
     if (existingSetting != null) {
       existingSetting.value = isActive.toString();
       await _settingRepository.update(existingSetting);
@@ -62,6 +75,7 @@ class DesktopStartupSettingsService implements IStartupSettingsService {
 
   @override
   Future<void> disableStartAtStartup() async {
+    await _ensureSetup();
     await launchAtStartup.disable();
     await _saveSetting(false);
   }


### PR DESCRIPTION
Fixes #254 

This resolves the Windows crash when opening Settings page by:
- Moving blocking registry initialization out of constructor
- Lazy async setup runs only when startup functionality is actually accessed
- Added Windows platform check
- Added error handling with graceful fallback
- Prevents UI thread blocking which caused unresponsive app and crash