### PR TITLE
fix(habits): make notification completion idempotent

### DIFF
--- a/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/NotificationHelper.kt
+++ b/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/NotificationHelper.kt
@@ -149,20 +149,39 @@ class NotificationHelper(private val context: Context) {
     return payload?.contains("habitId") == true || payload?.contains("/habits") == true
   }
 
-  private fun buildCompleteAction(payload: String?, channelId: String, notificationId: Int): PendingIntent? {
+  private fun buildCompleteAction(
+    payload: String?,
+    channelId: String,
+    notificationId: Int,
+  ): PendingIntent? {
     val taskId = extractPayloadId(payload, "taskId")
     val habitId = extractPayloadId(payload, "habitId")
 
     return when {
       channelId == Constants.NotificationChannels.TASK_CHANNEL_ID && taskId != null ->
-        buildCompleteIntent(Constants.IntentActions.TASK_COMPLETE_ACTION, taskId, notificationId, idOffset = 1000)
+        buildCompleteIntent(
+          Constants.IntentActions.TASK_COMPLETE_ACTION,
+          taskId,
+          notificationId,
+          idOffset = 1000,
+        )
       channelId == Constants.NotificationChannels.HABIT_CHANNEL_ID && habitId != null ->
-        buildCompleteIntent(Constants.IntentActions.HABIT_COMPLETE_ACTION, habitId, notificationId, idOffset = 2000)
+        buildCompleteIntent(
+          Constants.IntentActions.HABIT_COMPLETE_ACTION,
+          habitId,
+          notificationId,
+          idOffset = 2000,
+        )
       else -> null
     }
   }
 
-  private fun buildCompleteIntent(action: String, entityId: String, notificationId: Int, idOffset: Int): PendingIntent {
+  private fun buildCompleteIntent(
+    action: String,
+    entityId: String,
+    notificationId: Int,
+    idOffset: Int,
+  ): PendingIntent {
     val completeIntent =
       Intent(context, NotificationReceiver::class.java).apply {
         this.action = action

--- a/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/NotificationHelper.kt
+++ b/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/NotificationHelper.kt
@@ -108,7 +108,7 @@ class NotificationHelper(private val context: Context) {
 
     val channelId = resolveNotificationChannel(payload)
 
-    val completePendingIntent = buildCompleteAction(payload, channelId)
+    val completePendingIntent = buildCompleteAction(payload, channelId, id)
 
     val builder =
       NotificationCompat.Builder(context, channelId)
@@ -149,20 +149,20 @@ class NotificationHelper(private val context: Context) {
     return payload?.contains("habitId") == true || payload?.contains("/habits") == true
   }
 
-  private fun buildCompleteAction(payload: String?, channelId: String): PendingIntent? {
+  private fun buildCompleteAction(payload: String?, channelId: String, notificationId: Int): PendingIntent? {
     val taskId = extractPayloadId(payload, "taskId")
     val habitId = extractPayloadId(payload, "habitId")
 
     return when {
       channelId == Constants.NotificationChannels.TASK_CHANNEL_ID && taskId != null ->
-        buildCompleteIntent(Constants.IntentActions.TASK_COMPLETE_ACTION, taskId, idOffset = 1000)
+        buildCompleteIntent(Constants.IntentActions.TASK_COMPLETE_ACTION, taskId, notificationId, idOffset = 1000)
       channelId == Constants.NotificationChannels.HABIT_CHANNEL_ID && habitId != null ->
-        buildCompleteIntent(Constants.IntentActions.HABIT_COMPLETE_ACTION, habitId, idOffset = 2000)
+        buildCompleteIntent(Constants.IntentActions.HABIT_COMPLETE_ACTION, habitId, notificationId, idOffset = 2000)
       else -> null
     }
   }
 
-  private fun buildCompleteIntent(action: String, entityId: String, idOffset: Int): PendingIntent {
+  private fun buildCompleteIntent(action: String, entityId: String, notificationId: Int, idOffset: Int): PendingIntent {
     val completeIntent =
       Intent(context, NotificationReceiver::class.java).apply {
         this.action = action
@@ -171,10 +171,11 @@ class NotificationHelper(private val context: Context) {
           else Constants.IntentExtras.HABIT_ID,
           entityId,
         )
+        putExtra(Constants.IntentExtras.NOTIFICATION_ID, notificationId)
       }
     return PendingIntent.getBroadcast(
       context,
-      idOffset,
+      idOffset + notificationId,
       completeIntent,
       PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
     )

--- a/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/NotificationHelper.kt
+++ b/src/android/app/src/main/kotlin/me/ahmetcetinkaya/whph/NotificationHelper.kt
@@ -55,7 +55,7 @@ class NotificationHelper(private val context: Context) {
       NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH).apply {
         this.description = description
         enableLights(true)
-        lightColor = lightColor
+        this.lightColor = lightColor
         enableVibration(true)
         setSound(
           RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),

--- a/src/lib/core/application/features/habits/commands/complete_habit_command.dart
+++ b/src/lib/core/application/features/habits/commands/complete_habit_command.dart
@@ -59,17 +59,10 @@ class CompleteHabitCommandHandler implements IRequestHandler<CompleteHabitComman
       1000,
     );
 
-    final dayRecords = habitRecords.items
-        .where((record) =>
-            record.habitId == request.habitId &&
-            DateTimeHelper.isSameDay(
-              DateTimeHelper.toLocalDateTime(record.occurredAt),
-              targetDate,
-            ))
-        .toList();
+    final dayRecords = habitRecords.items;
 
     final completeRecords = dayRecords.where((record) => record.status == HabitRecordStatus.complete).toList();
-    final dailyTarget = habit.hasGoal ? (habit.dailyTarget ?? 1) : 1;
+    final dailyTarget = habit.getDailyTarget();
     final isMultiOccurrence = habit.hasGoal && dailyTarget > 1;
 
     await AppDatabase.instance().transaction(() async {

--- a/src/lib/core/application/features/habits/commands/complete_habit_command.dart
+++ b/src/lib/core/application/features/habits/commands/complete_habit_command.dart
@@ -38,34 +38,33 @@ class CompleteHabitCommandHandler implements IRequestHandler<CompleteHabitComman
 
   @override
   Future<CompleteHabitCommandResponse> call(CompleteHabitCommand request) async {
-    final habit = await _habitRepository.getById(request.habitId);
-    if (habit == null) {
-      throw BusinessException(
-        'Habit not found',
-        HabitTranslationKeys.habitNotFoundError,
-        args: {'habitId': request.habitId},
-      );
-    }
-
     final targetDate = DateTimeHelper.toLocalDateTime(request.date);
     final startOfDay = DateTime(targetDate.year, targetDate.month, targetDate.day).toUtc();
     final endOfDay = startOfDay.add(const Duration(days: 1)).subtract(const Duration(microseconds: 1));
 
-    final habitRecords = await _habitRecordRepository.getListByHabitIdAndRangeDate(
-      request.habitId,
-      startOfDay,
-      endOfDay,
-      0,
-      1000,
-    );
-
-    final dayRecords = habitRecords.items;
-
-    final completeRecords = dayRecords.where((record) => record.status == HabitRecordStatus.complete).toList();
-    final dailyTarget = habit.getDailyTarget();
-    final isMultiOccurrence = habit.hasGoal && dailyTarget > 1;
-
     await AppDatabase.instance().transaction(() async {
+      final habit = await _habitRepository.getById(request.habitId);
+      if (habit == null) {
+        throw BusinessException(
+          'Habit not found',
+          HabitTranslationKeys.habitNotFoundError,
+          args: {'habitId': request.habitId},
+        );
+      }
+
+      final habitRecords = await _habitRecordRepository.getListByHabitIdAndRangeDate(
+        request.habitId,
+        startOfDay,
+        endOfDay,
+        0,
+        1000,
+      );
+
+      final dayRecords = habitRecords.items;
+      final completeRecords = dayRecords.where((record) => record.status == HabitRecordStatus.complete).toList();
+      final dailyTarget = habit.getDailyTarget();
+      final isMultiOccurrence = habit.hasGoal && dailyTarget > 1;
+
       if (isMultiOccurrence) {
         await _clearNonCompleteRecords(dayRecords);
 

--- a/src/lib/core/application/features/habits/commands/complete_habit_command.dart
+++ b/src/lib/core/application/features/habits/commands/complete_habit_command.dart
@@ -1,0 +1,136 @@
+import 'package:acore/acore.dart';
+import 'package:mediatr/mediatr.dart';
+import 'package:whph/core/application/features/habits/constants/habit_translation_keys.dart';
+import 'package:whph/core/application/features/habits/services/habit_time_record_service.dart';
+import 'package:whph/core/application/features/habits/services/i_habit_record_repository.dart';
+import 'package:whph/core/application/features/habits/services/i_habit_repository.dart';
+import 'package:whph/core/application/features/habits/services/i_habit_time_record_repository.dart';
+import 'package:whph/core/application/shared/utils/key_helper.dart';
+import 'package:whph/core/domain/features/habits/habit.dart';
+import 'package:whph/core/domain/features/habits/habit_record.dart';
+import 'package:whph/core/domain/features/habits/habit_record_status.dart';
+import 'package:whph/infrastructure/persistence/shared/contexts/drift/drift_app_context.dart';
+
+class CompleteHabitCommand implements IRequest<CompleteHabitCommandResponse> {
+  final String habitId;
+  final DateTime date;
+
+  CompleteHabitCommand({
+    required this.habitId,
+    required this.date,
+  });
+}
+
+class CompleteHabitCommandResponse {}
+
+class CompleteHabitCommandHandler implements IRequestHandler<CompleteHabitCommand, CompleteHabitCommandResponse> {
+  final IHabitRepository _habitRepository;
+  final IHabitRecordRepository _habitRecordRepository;
+  final IHabitTimeRecordRepository _habitTimeRecordRepository;
+
+  CompleteHabitCommandHandler({
+    required IHabitRepository habitRepository,
+    required IHabitRecordRepository habitRecordRepository,
+    required IHabitTimeRecordRepository habitTimeRecordRepository,
+  })  : _habitRepository = habitRepository,
+        _habitRecordRepository = habitRecordRepository,
+        _habitTimeRecordRepository = habitTimeRecordRepository;
+
+  @override
+  Future<CompleteHabitCommandResponse> call(CompleteHabitCommand request) async {
+    final habit = await _habitRepository.getById(request.habitId);
+    if (habit == null) {
+      throw BusinessException(
+        'Habit not found',
+        HabitTranslationKeys.habitNotFoundError,
+        args: {'habitId': request.habitId},
+      );
+    }
+
+    final targetDate = DateTimeHelper.toLocalDateTime(request.date);
+    final startOfDay = DateTime(targetDate.year, targetDate.month, targetDate.day).toUtc();
+    final endOfDay = startOfDay.add(const Duration(days: 1)).subtract(const Duration(microseconds: 1));
+
+    final habitRecords = await _habitRecordRepository.getListByHabitIdAndRangeDate(
+      request.habitId,
+      startOfDay,
+      endOfDay,
+      0,
+      1000,
+    );
+
+    final dayRecords = habitRecords.items
+        .where((record) =>
+            record.habitId == request.habitId &&
+            DateTimeHelper.isSameDay(
+              DateTimeHelper.toLocalDateTime(record.occurredAt),
+              targetDate,
+            ))
+        .toList();
+
+    final completeRecords = dayRecords.where((record) => record.status == HabitRecordStatus.complete).toList();
+    final dailyTarget = habit.hasGoal ? (habit.dailyTarget ?? 1) : 1;
+    final isMultiOccurrence = habit.hasGoal && dailyTarget > 1;
+
+    await AppDatabase.instance().transaction(() async {
+      if (isMultiOccurrence) {
+        await _clearNonCompleteRecords(dayRecords);
+
+        if (completeRecords.length < dailyTarget) {
+          await _addCompleteRecord(habit, request.habitId, request.date);
+        }
+        return;
+      }
+
+      if (completeRecords.isNotEmpty) {
+        await _keepOnlyFirstCompleteRecord(dayRecords, completeRecords.first);
+        return;
+      }
+
+      await _clearRecords(dayRecords);
+      await _addCompleteRecord(habit, request.habitId, request.date);
+    });
+
+    return CompleteHabitCommandResponse();
+  }
+
+  Future<void> _addCompleteRecord(Habit habit, String habitId, DateTime date) async {
+    final occurredAt = DateTimeHelper.toUtcDateTime(date);
+    await _habitRecordRepository.add(HabitRecord(
+      id: KeyHelper.generateStringId(),
+      createdDate: DateTime.now().toUtc(),
+      habitId: habitId,
+      occurredAt: occurredAt,
+      status: HabitRecordStatus.complete,
+    ));
+
+    if (habit.estimatedTime != null && habit.estimatedTime! > 0) {
+      await HabitTimeRecordService.addEstimatedDurationToHabitTimeRecord(
+        repository: _habitTimeRecordRepository,
+        habitId: habitId,
+        targetDate: occurredAt,
+        estimatedDuration: (habit.estimatedTime! * 60).toInt(),
+      );
+    }
+  }
+
+  Future<void> _clearNonCompleteRecords(List<HabitRecord> records) async {
+    for (final record in records.where((record) => record.status != HabitRecordStatus.complete)) {
+      await _habitRecordRepository.delete(record);
+    }
+  }
+
+  Future<void> _keepOnlyFirstCompleteRecord(List<HabitRecord> records, HabitRecord completeRecordToKeep) async {
+    for (final record in records) {
+      if (record.id != completeRecordToKeep.id) {
+        await _habitRecordRepository.delete(record);
+      }
+    }
+  }
+
+  Future<void> _clearRecords(List<HabitRecord> records) async {
+    for (final record in records) {
+      await _habitRecordRepository.delete(record);
+    }
+  }
+}

--- a/src/lib/core/application/features/habits/commands/complete_habit_command.dart
+++ b/src/lib/core/application/features/habits/commands/complete_habit_command.dart
@@ -1,11 +1,9 @@
 import 'package:acore/acore.dart';
 import 'package:mediatr/mediatr.dart';
 import 'package:whph/core/application/features/habits/constants/habit_translation_keys.dart';
-import 'package:whph/core/application/features/habits/services/habit_time_record_service.dart';
+import 'package:whph/core/application/features/habits/services/habit_record_operations_service.dart';
 import 'package:whph/core/application/features/habits/services/i_habit_record_repository.dart';
 import 'package:whph/core/application/features/habits/services/i_habit_repository.dart';
-import 'package:whph/core/application/features/habits/services/i_habit_time_record_repository.dart';
-import 'package:whph/core/application/shared/utils/key_helper.dart';
 import 'package:whph/core/domain/features/habits/habit.dart';
 import 'package:whph/core/domain/features/habits/habit_record.dart';
 import 'package:whph/core/domain/features/habits/habit_record_status.dart';
@@ -26,15 +24,15 @@ class CompleteHabitCommandResponse {}
 class CompleteHabitCommandHandler implements IRequestHandler<CompleteHabitCommand, CompleteHabitCommandResponse> {
   final IHabitRepository _habitRepository;
   final IHabitRecordRepository _habitRecordRepository;
-  final IHabitTimeRecordRepository _habitTimeRecordRepository;
+  final HabitRecordOperationsService _operationsService;
 
   CompleteHabitCommandHandler({
     required IHabitRepository habitRepository,
     required IHabitRecordRepository habitRecordRepository,
-    required IHabitTimeRecordRepository habitTimeRecordRepository,
+    required HabitRecordOperationsService operationsService,
   })  : _habitRepository = habitRepository,
         _habitRecordRepository = habitRecordRepository,
-        _habitTimeRecordRepository = habitTimeRecordRepository;
+        _operationsService = operationsService;
 
   @override
   Future<CompleteHabitCommandResponse> call(CompleteHabitCommand request) async {
@@ -88,22 +86,21 @@ class CompleteHabitCommandHandler implements IRequestHandler<CompleteHabitComman
 
   Future<void> _addCompleteRecord(Habit habit, String habitId, DateTime date) async {
     final occurredAt = DateTimeHelper.toUtcDateTime(date);
-    await _habitRecordRepository.add(HabitRecord(
-      id: KeyHelper.generateStringId(),
-      createdDate: DateTime.now().toUtc(),
-      habitId: habitId,
-      occurredAt: occurredAt,
-      status: HabitRecordStatus.complete,
-    ));
+    final now = DateTime.now().toUtc();
 
-    if (habit.estimatedTime != null && habit.estimatedTime! > 0) {
-      await HabitTimeRecordService.addEstimatedDurationToHabitTimeRecord(
-        repository: _habitTimeRecordRepository,
-        habitId: habitId,
-        targetDate: occurredAt,
-        estimatedDuration: (habit.estimatedTime! * 60).toInt(),
-      );
-    }
+    await _operationsService.addHabitRecord(
+      habitId,
+      occurredAt,
+      HabitRecordStatus.complete,
+      now,
+    );
+
+    await _operationsService.addTimeRecordIfComplete(
+      habit,
+      habitId,
+      occurredAt,
+      HabitRecordStatus.complete,
+    );
   }
 
   Future<void> _clearNonCompleteRecords(List<HabitRecord> records) async {

--- a/src/lib/core/application/features/habits/commands/complete_habit_command.dart
+++ b/src/lib/core/application/features/habits/commands/complete_habit_command.dart
@@ -64,7 +64,7 @@ class CompleteHabitCommandHandler implements IRequestHandler<CompleteHabitComman
       final isMultiOccurrence = habit.hasGoal && dailyTarget > 1;
 
       if (isMultiOccurrence) {
-        await _clearNonCompleteRecords(dayRecords);
+        await _clearNonCompleteRecords(request.habitId, startOfDay, endOfDay, dayRecords);
 
         if (completeRecords.length < dailyTarget) {
           await _addCompleteRecord(habit, request.habitId, request.date);
@@ -73,11 +73,11 @@ class CompleteHabitCommandHandler implements IRequestHandler<CompleteHabitComman
       }
 
       if (completeRecords.isNotEmpty) {
-        await _keepOnlyFirstCompleteRecord(dayRecords, completeRecords.first);
+        await _keepOnlyFirstCompleteRecord(request.habitId, startOfDay, endOfDay, dayRecords, completeRecords.first);
         return;
       }
 
-      await _clearRecords(dayRecords);
+      await _clearRecords(request.habitId, startOfDay, endOfDay, dayRecords);
       await _addCompleteRecord(habit, request.habitId, request.date);
     });
 
@@ -103,23 +103,25 @@ class CompleteHabitCommandHandler implements IRequestHandler<CompleteHabitComman
     );
   }
 
-  Future<void> _clearNonCompleteRecords(List<HabitRecord> records) async {
-    for (final record in records.where((record) => record.status != HabitRecordStatus.complete)) {
-      await _habitRecordRepository.delete(record);
+  Future<void> _clearNonCompleteRecords(
+      String habitId, DateTime startOfDay, DateTime endOfDay, List<HabitRecord> records) async {
+    final nonCompleteRecords = records.where((record) => record.status != HabitRecordStatus.complete).toList();
+    if (nonCompleteRecords.isNotEmpty) {
+      await _operationsService.clearAllRecordsForDay(habitId, startOfDay, endOfDay, nonCompleteRecords);
     }
   }
 
-  Future<void> _keepOnlyFirstCompleteRecord(List<HabitRecord> records, HabitRecord completeRecordToKeep) async {
-    for (final record in records) {
-      if (record.id != completeRecordToKeep.id) {
-        await _habitRecordRepository.delete(record);
-      }
+  Future<void> _keepOnlyFirstCompleteRecord(String habitId, DateTime startOfDay, DateTime endOfDay,
+      List<HabitRecord> records, HabitRecord completeRecordToKeep) async {
+    final recordsToDelete = records.where((record) => record.id != completeRecordToKeep.id).toList();
+    if (recordsToDelete.isNotEmpty) {
+      await _operationsService.clearAllRecordsForDay(habitId, startOfDay, endOfDay, recordsToDelete);
     }
   }
 
-  Future<void> _clearRecords(List<HabitRecord> records) async {
-    for (final record in records) {
-      await _habitRecordRepository.delete(record);
+  Future<void> _clearRecords(String habitId, DateTime startOfDay, DateTime endOfDay, List<HabitRecord> records) async {
+    if (records.isNotEmpty) {
+      await _operationsService.clearAllRecordsForDay(habitId, startOfDay, endOfDay, records);
     }
   }
 }

--- a/src/lib/core/application/features/habits/commands/toggle_habit_completion_command.dart
+++ b/src/lib/core/application/features/habits/commands/toggle_habit_completion_command.dart
@@ -1,14 +1,10 @@
 // ignore_for_file: unused_local_variable
 
 import 'package:mediatr/mediatr.dart';
+import 'package:whph/core/application/features/habits/services/habit_record_operations_service.dart';
 import 'package:whph/core/application/features/habits/services/i_habit_repository.dart';
 import 'package:whph/core/application/features/habits/services/i_habit_record_repository.dart';
-import 'package:whph/core/application/features/habits/services/i_habit_time_record_repository.dart';
 import 'package:whph/core/application/features/habits/constants/habit_translation_keys.dart';
-import 'package:whph/core/application/shared/utils/key_helper.dart';
-import 'package:whph/core/application/features/habits/services/habit_time_record_service.dart';
-import 'package:whph/core/domain/features/habits/habit.dart';
-import 'package:whph/core/domain/features/habits/habit_record.dart';
 import 'package:whph/core/domain/features/habits/habit_record_status.dart';
 import 'package:acore/acore.dart';
 
@@ -34,18 +30,18 @@ class ToggleHabitCompletionCommandHandler
     implements IRequestHandler<ToggleHabitCompletionCommand, ToggleHabitCompletionCommandResponse> {
   final IHabitRepository _habitRepository;
   final IHabitRecordRepository _habitRecordRepository;
-  final IHabitTimeRecordRepository _habitTimeRecordRepository;
   final ISettingRepository _settingsRepository;
+  final HabitRecordOperationsService _operationsService;
 
   ToggleHabitCompletionCommandHandler({
     required IHabitRepository habitRepository,
     required IHabitRecordRepository habitRecordRepository,
-    required IHabitTimeRecordRepository habitTimeRecordRepository,
     required ISettingRepository settingsRepository,
+    required HabitRecordOperationsService operationsService,
   })  : _habitRepository = habitRepository,
         _habitRecordRepository = habitRecordRepository,
-        _habitTimeRecordRepository = habitTimeRecordRepository,
-        _settingsRepository = settingsRepository;
+        _settingsRepository = settingsRepository,
+        _operationsService = operationsService;
 
   @override
   Future<ToggleHabitCompletionCommandResponse> call(ToggleHabitCompletionCommand request) async {
@@ -141,11 +137,12 @@ class ToggleHabitCompletionCommandHandler
       if (!isMultiOccurrence) {
         // Only clear for single occurrence habits where we are replacing the state
         // Always clear existing records for single-occurrence logic to ensure strict 1-to-1 state mapping
-        await _clearAllRecordsForDay(request.habitId, startOfDay, endOfDay, habitRecords.items.toList());
+        await _operationsService.clearAllRecordsForDay(
+            request.habitId, startOfDay, endOfDay, habitRecords.items.toList());
 
         if (nextStatus != HabitRecordStatus.skipped) {
           // Add new record
-          await _addHabitRecord(
+          await _operationsService.addHabitRecord(
             request.habitId,
             occurredAt,
             nextStatus,
@@ -153,7 +150,7 @@ class ToggleHabitCompletionCommandHandler
           );
 
           // Add time record ONLY if complete
-          await _addTimeRecordIfComplete(
+          await _operationsService.addTimeRecordIfComplete(
             habit,
             request.habitId,
             occurredAt,
@@ -163,14 +160,14 @@ class ToggleHabitCompletionCommandHandler
       } else {
         if (nextStatus == HabitRecordStatus.complete) {
           // Add ONE record
-          await _addHabitRecord(
+          await _operationsService.addHabitRecord(
             request.habitId,
             occurredAt,
             HabitRecordStatus.complete,
             now,
           );
 
-          await _addTimeRecordIfComplete(
+          await _operationsService.addTimeRecordIfComplete(
             habit,
             request.habitId,
             occurredAt,
@@ -178,10 +175,11 @@ class ToggleHabitCompletionCommandHandler
           );
         } else if (nextStatus == HabitRecordStatus.notDone) {
           // Switch to Not Done - Clear all existing attempts first
-          await _clearAllRecordsForDay(request.habitId, startOfDay, endOfDay, habitRecords.items.toList());
+          await _operationsService.clearAllRecordsForDay(
+              request.habitId, startOfDay, endOfDay, habitRecords.items.toList());
 
           // Add ONE Not Done record
-          await _addHabitRecord(
+          await _operationsService.addHabitRecord(
             request.habitId,
             occurredAt,
             HabitRecordStatus.notDone,
@@ -189,59 +187,12 @@ class ToggleHabitCompletionCommandHandler
           );
         } else {
           // Reset (Skipped) - Clear all
-          await _clearAllRecordsForDay(request.habitId, startOfDay, endOfDay, habitRecords.items.toList());
+          await _operationsService.clearAllRecordsForDay(
+              request.habitId, startOfDay, endOfDay, habitRecords.items.toList());
         }
       }
     });
 
     return ToggleHabitCompletionCommandResponse();
-  }
-
-  Future<void> _addHabitRecord(
-    String habitId,
-    DateTime occurredAt,
-    HabitRecordStatus status,
-    DateTime createdDate,
-  ) async {
-    final habitRecord = HabitRecord(
-      id: KeyHelper.generateStringId(),
-      createdDate: createdDate,
-      habitId: habitId,
-      occurredAt: occurredAt,
-      status: status,
-    );
-    await _habitRecordRepository.add(habitRecord);
-  }
-
-  Future<void> _addTimeRecordIfComplete(
-    Habit habit,
-    String habitId,
-    DateTime occurredAt,
-    HabitRecordStatus status,
-  ) async {
-    if (status == HabitRecordStatus.complete && habit.estimatedTime != null && habit.estimatedTime! > 0) {
-      await HabitTimeRecordService.addEstimatedDurationToHabitTimeRecord(
-        repository: _habitTimeRecordRepository,
-        habitId: habitId,
-        targetDate: occurredAt,
-        estimatedDuration: (habit.estimatedTime! * 60).toInt(),
-      );
-    }
-  }
-
-  Future<void> _clearAllRecordsForDay(
-      String habitId, DateTime startOfDay, DateTime endOfDay, List<HabitRecord> recordsToDelete) async {
-    for (final habitRecord in recordsToDelete) {
-      await _habitRecordRepository.delete(habitRecord);
-    }
-
-    final timeRecords = await _habitTimeRecordRepository.getByHabitIdAndDateRange(
-      habitId,
-      startOfDay,
-      endOfDay,
-    );
-    for (final timeRecord in timeRecords) {
-      await _habitTimeRecordRepository.delete(timeRecord);
-    }
   }
 }

--- a/src/lib/core/application/features/habits/commands/toggle_habit_completion_command.dart
+++ b/src/lib/core/application/features/habits/commands/toggle_habit_completion_command.dart
@@ -141,7 +141,6 @@ class ToggleHabitCompletionCommandHandler
             request.habitId, startOfDay, endOfDay, habitRecords.items.toList());
 
         if (nextStatus != HabitRecordStatus.skipped) {
-          // Add new record
           await _operationsService.addHabitRecord(
             request.habitId,
             occurredAt,
@@ -149,7 +148,6 @@ class ToggleHabitCompletionCommandHandler
             now,
           );
 
-          // Add time record ONLY if complete
           await _operationsService.addTimeRecordIfComplete(
             habit,
             request.habitId,
@@ -159,7 +157,6 @@ class ToggleHabitCompletionCommandHandler
         }
       } else {
         if (nextStatus == HabitRecordStatus.complete) {
-          // Add ONE record
           await _operationsService.addHabitRecord(
             request.habitId,
             occurredAt,
@@ -178,7 +175,6 @@ class ToggleHabitCompletionCommandHandler
           await _operationsService.clearAllRecordsForDay(
               request.habitId, startOfDay, endOfDay, habitRecords.items.toList());
 
-          // Add ONE Not Done record
           await _operationsService.addHabitRecord(
             request.habitId,
             occurredAt,

--- a/src/lib/core/application/features/habits/habits_registration.dart
+++ b/src/lib/core/application/features/habits/habits_registration.dart
@@ -2,6 +2,7 @@ import 'package:mediatr/mediatr.dart';
 import 'package:whph/core/application/features/habits/commands/add_habit_record_command.dart';
 import 'package:whph/core/application/features/habits/commands/add_habit_tag_command.dart';
 import 'package:whph/core/application/features/habits/commands/add_habit_time_record_command.dart';
+import 'package:whph/core/application/features/habits/commands/complete_habit_command.dart';
 import 'package:whph/core/application/features/habits/commands/save_habit_time_record_command.dart';
 import 'package:whph/core/application/features/habits/commands/delete_habit_record_command.dart';
 import 'package:whph/core/application/features/habits/commands/toggle_habit_completion_command.dart';
@@ -63,6 +64,13 @@ void registerHabitsFeature(
       () => AddHabitRecordCommandHandler(
         habitRecordRepository: habitRecordRepository,
         habitRepository: habitRepository,
+        habitTimeRecordRepository: habitTimeRecordRepository,
+      ),
+    )
+    ..registerHandler<CompleteHabitCommand, CompleteHabitCommandResponse, CompleteHabitCommandHandler>(
+      () => CompleteHabitCommandHandler(
+        habitRepository: habitRepository,
+        habitRecordRepository: habitRecordRepository,
         habitTimeRecordRepository: habitTimeRecordRepository,
       ),
     )

--- a/src/lib/core/application/features/habits/habits_registration.dart
+++ b/src/lib/core/application/features/habits/habits_registration.dart
@@ -18,6 +18,7 @@ import 'package:acore/acore.dart';
 import 'package:whph/core/application/features/habits/commands/save_habit_command.dart';
 import 'package:whph/core/application/features/habits/commands/delete_habit_command.dart';
 import 'package:whph/core/application/features/habits/queries/get_list_habits_query.dart';
+import 'package:whph/core/application/features/habits/services/habit_record_operations_service.dart';
 import 'package:whph/core/application/features/habits/services/i_habit_repository.dart';
 import 'package:whph/core/application/features/habits/services/i_habit_record_repository.dart';
 import 'package:whph/core/application/features/habits/services/i_habit_tags_repository.dart';
@@ -35,6 +36,11 @@ void registerHabitsFeature(
   ITagRepository tagRepository,
   ISettingRepository settingsRepository,
 ) {
+  final habitRecordOperationsService = HabitRecordOperationsService(
+    habitRecordRepository: habitRecordRepository,
+    habitTimeRecordRepository: habitTimeRecordRepository,
+  );
+
   mediator
     ..registerHandler<SaveHabitCommand, SaveHabitCommandResponse, SaveHabitCommandHandler>(
       () => SaveHabitCommandHandler(habitRepository: habitRepository),
@@ -71,7 +77,7 @@ void registerHabitsFeature(
       () => CompleteHabitCommandHandler(
         habitRepository: habitRepository,
         habitRecordRepository: habitRecordRepository,
-        habitTimeRecordRepository: habitTimeRecordRepository,
+        operationsService: habitRecordOperationsService,
       ),
     )
     ..registerHandler<AddHabitTimeRecordCommand, AddHabitTimeRecordCommandResponse, AddHabitTimeRecordCommandHandler>(
@@ -120,8 +126,8 @@ void registerHabitsFeature(
       () => ToggleHabitCompletionCommandHandler(
         habitRepository: habitRepository,
         habitRecordRepository: habitRecordRepository,
-        habitTimeRecordRepository: habitTimeRecordRepository,
         settingsRepository: settingsRepository,
+        operationsService: habitRecordOperationsService,
       ),
     );
 }

--- a/src/lib/core/application/features/habits/services/habit_record_operations_service.dart
+++ b/src/lib/core/application/features/habits/services/habit_record_operations_service.dart
@@ -1,0 +1,70 @@
+import 'package:whph/core/application/features/habits/services/habit_time_record_service.dart';
+import 'package:whph/core/application/features/habits/services/i_habit_record_repository.dart';
+import 'package:whph/core/application/features/habits/services/i_habit_time_record_repository.dart';
+import 'package:whph/core/application/shared/utils/key_helper.dart';
+import 'package:whph/core/domain/features/habits/habit.dart';
+import 'package:whph/core/domain/features/habits/habit_record.dart';
+import 'package:whph/core/domain/features/habits/habit_record_status.dart';
+
+class HabitRecordOperationsService {
+  final IHabitRecordRepository _habitRecordRepository;
+  final IHabitTimeRecordRepository _habitTimeRecordRepository;
+
+  HabitRecordOperationsService({
+    required IHabitRecordRepository habitRecordRepository,
+    required IHabitTimeRecordRepository habitTimeRecordRepository,
+  })  : _habitRecordRepository = habitRecordRepository,
+        _habitTimeRecordRepository = habitTimeRecordRepository;
+
+  Future<void> addHabitRecord(
+    String habitId,
+    DateTime occurredAt,
+    HabitRecordStatus status,
+    DateTime createdDate,
+  ) async {
+    final habitRecord = HabitRecord(
+      id: KeyHelper.generateStringId(),
+      createdDate: createdDate,
+      habitId: habitId,
+      occurredAt: occurredAt,
+      status: status,
+    );
+    await _habitRecordRepository.add(habitRecord);
+  }
+
+  Future<void> addTimeRecordIfComplete(
+    Habit habit,
+    String habitId,
+    DateTime occurredAt,
+    HabitRecordStatus status,
+  ) async {
+    if (status == HabitRecordStatus.complete && habit.estimatedTime != null && habit.estimatedTime! > 0) {
+      await HabitTimeRecordService.addEstimatedDurationToHabitTimeRecord(
+        repository: _habitTimeRecordRepository,
+        habitId: habitId,
+        targetDate: occurredAt,
+        estimatedDuration: (habit.estimatedTime! * 60).toInt(),
+      );
+    }
+  }
+
+  Future<void> clearAllRecordsForDay(
+    String habitId,
+    DateTime startOfDay,
+    DateTime endOfDay,
+    List<HabitRecord> recordsToDelete,
+  ) async {
+    for (final habitRecord in recordsToDelete) {
+      await _habitRecordRepository.delete(habitRecord);
+    }
+
+    final timeRecords = await _habitTimeRecordRepository.getByHabitIdAndDateRange(
+      habitId,
+      startOfDay,
+      endOfDay,
+    );
+    for (final timeRecord in timeRecords) {
+      await _habitTimeRecordRepository.delete(timeRecord);
+    }
+  }
+}

--- a/src/lib/infrastructure/desktop/features/notification/desktop_notification_service.dart
+++ b/src/lib/infrastructure/desktop/features/notification/desktop_notification_service.dart
@@ -11,6 +11,7 @@ import 'package:whph/infrastructure/shared/features/notification/base_notificati
 import 'package:whph/infrastructure/shared/features/window/abstractions/i_window_manager.dart';
 import 'package:whph/infrastructure/windows/constants/windows_app_constants.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_notification_service.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_task_notification_handler.dart';
 
 class DesktopNotificationService extends BaseNotificationService {
   @override
@@ -19,14 +20,17 @@ class DesktopNotificationService extends BaseNotificationService {
   final FlutterLocalNotificationsPlugin _flutterLocalNotifications;
   final IWindowManager _windowManager;
   final INotificationPayloadHandler _payloadHandler;
+  final ITaskNotificationHandler _taskNotificationHandler;
 
   DesktopNotificationService(
     super.mediator,
     IWindowManager windowManager,
     INotificationPayloadHandler payloadHandler,
+    ITaskNotificationHandler taskNotificationHandler,
   )   : _flutterLocalNotifications = FlutterLocalNotificationsPlugin(),
         _windowManager = windowManager,
-        _payloadHandler = payloadHandler;
+        _payloadHandler = payloadHandler,
+        _taskNotificationHandler = taskNotificationHandler;
 
   @override
   Future<void> init() async {
@@ -69,7 +73,7 @@ class DesktopNotificationService extends BaseNotificationService {
       if (payload != null) {
         final taskId = _extractTaskIdFromPayload(payload);
         if (taskId != null) {
-          await handleNotificationTaskCompletion(taskId);
+          await _taskNotificationHandler.handleNotificationTaskCompletion(taskId);
         }
       }
       return;

--- a/src/lib/infrastructure/infrastructure_container.dart
+++ b/src/lib/infrastructure/infrastructure_container.dart
@@ -16,26 +16,39 @@ import 'package:whph/core/application/shared/services/abstraction/i_application_
 import 'package:whph/core/application/shared/services/abstraction/i_setup_service.dart';
 import 'package:whph/core/application/shared/services/abstraction/i_single_instance_service.dart';
 import 'package:acore/acore.dart';
+import 'package:whph/infrastructure/android/features/app_usage/android_app_usage_service.dart';
+import 'package:whph/infrastructure/android/features/reminder/android_reminder_service.dart';
 import 'package:whph/infrastructure/android/features/settings/android_startup_settings_service.dart';
+import 'package:whph/infrastructure/android/features/sync/android_server_sync_service.dart';
+import 'package:whph/infrastructure/android/features/sync/android_sync_service.dart';
 import 'package:whph/infrastructure/desktop/features/notification/desktop_notification_service.dart';
 import 'package:whph/infrastructure/desktop/features/reminder/desktop_reminder_service.dart';
-import 'package:whph/infrastructure/desktop/settings/desktop_startup_settings_service.dart';
+import 'package:whph/infrastructure/desktop/features/system_tray/desktop_system_tray_service.dart';
 import 'package:whph/infrastructure/desktop/features/sync/desktop_sync_service.dart';
-import 'package:whph/infrastructure/linux/features/setup/linux_setup_service.dart';
-import 'package:whph/infrastructure/android/features/app_usage/android_app_usage_service.dart';
-import 'package:whph/infrastructure/android/features/sync/android_sync_service.dart';
-import 'package:whph/infrastructure/android/features/sync/android_server_sync_service.dart';
+import 'package:whph/infrastructure/desktop/settings/desktop_startup_settings_service.dart';
 import 'package:whph/infrastructure/linux/features/app_usages/linux_app_usage_service.dart';
 import 'package:whph/infrastructure/linux/features/notification/flatpak_notification_service.dart';
+import 'package:whph/infrastructure/linux/features/setup/linux_setup_service.dart';
+import 'package:whph/infrastructure/linux/features/setup/services/abstraction/i_linux_desktop_service.dart';
+import 'package:whph/infrastructure/linux/features/setup/services/abstraction/i_linux_firewall_service.dart';
+import 'package:whph/infrastructure/linux/features/setup/services/abstraction/i_linux_kde_service.dart';
+import 'package:whph/infrastructure/linux/features/setup/services/abstraction/i_linux_update_service.dart';
+import 'package:whph/infrastructure/linux/features/setup/services/linux_desktop_service.dart';
+import 'package:whph/infrastructure/linux/features/setup/services/linux_firewall_service.dart';
+import 'package:whph/infrastructure/linux/features/setup/services/linux_kde_service.dart';
+import 'package:whph/infrastructure/linux/features/setup/services/linux_update_service.dart';
+import 'package:whph/infrastructure/linux/features/system_tray/flatpak_system_tray_service.dart';
 import 'package:whph/infrastructure/linux/features/window/linux_window_manager.dart';
+import 'package:whph/infrastructure/mobile/features/notification/mobile_notification_service.dart';
+import 'package:whph/infrastructure/mobile/features/system_tray/mobile_system_tray_service.dart';
 import 'package:whph/infrastructure/shared/features/notification/abstractions/i_notification_payload_handler.dart';
+import 'package:whph/infrastructure/shared/features/notification/habit_notification_handler.dart';
+import 'package:whph/infrastructure/shared/features/notification/task_notification_handler.dart';
+import 'package:whph/infrastructure/shared/features/wakelock/abstractions/i_wakelock_service.dart';
+import 'package:whph/infrastructure/shared/features/wakelock/wakelock_service.dart';
 import 'package:whph/infrastructure/shared/features/window/abstractions/i_window_manager.dart';
 import 'package:whph/infrastructure/shared/features/window/window_manager.dart';
 import 'package:whph/infrastructure/windows/features/app_usages/windows_app_usage_service.dart';
-import 'package:whph/infrastructure/android/features/reminder/android_reminder_service.dart';
-import 'package:whph/infrastructure/mobile/features/system_tray/mobile_system_tray_service.dart';
-import 'package:whph/infrastructure/shared/features/wakelock/abstractions/i_wakelock_service.dart';
-import 'package:whph/infrastructure/shared/features/wakelock/wakelock_service.dart';
 import 'package:whph/infrastructure/windows/features/setup/services/abstraction/i_windows_elevation_service.dart';
 import 'package:whph/infrastructure/windows/features/setup/services/abstraction/i_windows_firewall_service.dart';
 import 'package:whph/infrastructure/windows/features/setup/services/abstraction/i_windows_shortcut_service.dart';
@@ -45,21 +58,12 @@ import 'package:whph/infrastructure/windows/features/setup/services/windows_fire
 import 'package:whph/infrastructure/windows/features/setup/services/windows_shortcut_service.dart';
 import 'package:whph/infrastructure/windows/features/setup/services/windows_update_service.dart';
 import 'package:whph/infrastructure/windows/features/setup/windows_setup_service.dart';
-import 'package:whph/infrastructure/linux/features/setup/services/abstraction/i_linux_firewall_service.dart';
-import 'package:whph/infrastructure/linux/features/setup/services/abstraction/i_linux_desktop_service.dart';
-import 'package:whph/infrastructure/linux/features/setup/services/abstraction/i_linux_kde_service.dart';
-import 'package:whph/infrastructure/linux/features/setup/services/abstraction/i_linux_update_service.dart';
-import 'package:whph/infrastructure/linux/features/setup/services/linux_firewall_service.dart';
-import 'package:whph/infrastructure/linux/features/setup/services/linux_desktop_service.dart';
-import 'package:whph/infrastructure/linux/features/setup/services/linux_kde_service.dart';
-import 'package:whph/infrastructure/linux/features/setup/services/linux_update_service.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_habit_notification_handler.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_notification_service.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_reminder_service.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_startup_settings_service.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_system_tray_service.dart';
-import 'package:whph/infrastructure/desktop/features/system_tray/desktop_system_tray_service.dart';
-import 'package:whph/infrastructure/linux/features/system_tray/flatpak_system_tray_service.dart';
-import 'package:whph/infrastructure/mobile/features/notification/mobile_notification_service.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_task_notification_handler.dart';
 import 'package:whph/infrastructure/android/features/setup/android_setup_service.dart';
 import 'package:whph/infrastructure/android/features/file_system/android_file_service.dart';
 import 'package:whph/infrastructure/android/features/file_system/android_application_directory_service.dart';
@@ -119,13 +123,24 @@ void registerInfrastructure(IContainer container) {
         return FlatpakNotificationService(mediator, windowManager, payloadHandler);
       }
 
-      return DesktopNotificationService(mediator, windowManager, payloadHandler);
+      final taskHandler = container.resolve<ITaskNotificationHandler>();
+      return DesktopNotificationService(mediator, windowManager, payloadHandler, taskHandler);
     }
     if (PlatformUtils.isMobile) {
       return MobileNotificationService(mediator);
     }
 
     throw Exception('Unsupported platform for notification service.');
+  });
+
+  container.registerSingleton<ITaskNotificationHandler>((_) {
+    final mediator = container.resolve<Mediator>();
+    return TaskNotificationHandler(mediator);
+  });
+
+  container.registerSingleton<IHabitNotificationHandler>((_) {
+    final mediator = container.resolve<Mediator>();
+    return HabitNotificationHandler(mediator);
   });
 
   container.registerSingleton<ISystemTrayService>((_) {

--- a/src/lib/infrastructure/shared/features/notification/base_notification_service.dart
+++ b/src/lib/infrastructure/shared/features/notification/base_notification_service.dart
@@ -1,6 +1,6 @@
 import 'package:mediatr/mediatr.dart';
 
-import 'package:whph/core/application/features/habits/commands/toggle_habit_completion_command.dart';
+import 'package:whph/core/application/features/habits/commands/complete_habit_command.dart';
 import 'package:whph/core/application/features/settings/commands/save_setting_command.dart';
 import 'package:whph/core/application/features/settings/queries/get_setting_query.dart';
 import 'package:whph/core/application/features/tasks/commands/complete_task_command.dart';
@@ -43,8 +43,8 @@ abstract class BaseNotificationService implements INotificationService {
     try {
       Logger.info('$componentName: Completing habit from notification: $habitId', component: componentName);
 
-      await mediator.send<ToggleHabitCompletionCommand, ToggleHabitCompletionCommandResponse>(
-        ToggleHabitCompletionCommand(
+      await mediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+        CompleteHabitCommand(
           habitId: habitId,
           date: DateTime.now(),
         ),

--- a/src/lib/infrastructure/shared/features/notification/base_notification_service.dart
+++ b/src/lib/infrastructure/shared/features/notification/base_notification_service.dart
@@ -1,3 +1,4 @@
+import 'package:acore/acore.dart';
 import 'package:mediatr/mediatr.dart';
 
 import 'package:whph/core/application/features/habits/commands/complete_habit_command.dart';
@@ -28,7 +29,7 @@ abstract class BaseNotificationService implements INotificationService {
       );
 
       Logger.info('$componentName: Task completed successfully from notification', component: componentName);
-    } catch (e, stackTrace) {
+    } on BusinessException catch (e, stackTrace) {
       Logger.error(
         '[$TaskErrorIds.notificationActionFailed] $componentName: Failed to complete task',
         error: e,
@@ -51,7 +52,7 @@ abstract class BaseNotificationService implements INotificationService {
       );
 
       Logger.info('$componentName: Habit completed successfully from notification', component: componentName);
-    } catch (e, stackTrace) {
+    } on BusinessException catch (e, stackTrace) {
       Logger.error(
         '[$TaskErrorIds.notificationActionFailed] $componentName: Failed to complete habit',
         error: e,
@@ -68,29 +69,19 @@ abstract class BaseNotificationService implements INotificationService {
 
   @override
   Future<bool> isEnabled() async {
-    try {
-      final query = GetSettingQuery(key: SettingKeys.notifications);
-      final setting = await mediator.send<GetSettingQuery, GetSettingQueryResponse?>(query);
+    final query = GetSettingQuery(key: SettingKeys.notifications);
+    final setting = await mediator.send<GetSettingQuery, GetSettingQueryResponse?>(query);
 
-      if (setting == null) {
-        Logger.warning(
-          '$componentName: Notification setting not found, defaulting to enabled',
-          component: componentName,
-        );
-        return true; // Default to true if no setting
-      }
-
-      final isEnabled = setting.value == 'false' ? false : true;
-      return isEnabled;
-    } catch (e, stackTrace) {
-      Logger.error(
-        '[notification_check_failed] $componentName: Failed to check if notifications are enabled, defaulting to disabled',
-        error: e,
-        stackTrace: stackTrace,
+    if (setting == null) {
+      Logger.warning(
+        '$componentName: Notification setting not found, defaulting to enabled',
         component: componentName,
       );
-      return false; // Default to FALSE on error - safer to disable than to silently fail
+      return true; // Default to true if no setting
     }
+
+    final isEnabled = setting.value == 'false' ? false : true;
+    return isEnabled;
   }
 
   @override

--- a/src/lib/infrastructure/shared/features/notification/base_notification_service.dart
+++ b/src/lib/infrastructure/shared/features/notification/base_notification_service.dart
@@ -17,6 +17,10 @@ abstract class BaseNotificationService implements INotificationService {
   /// The component name to use for logging
   String get componentName;
 
+  /// Callback invoked after successful habit completion from notification.
+  /// Used to notify the UI layer to refresh habit lists.
+  void Function(String habitId)? onHabitCompleted;
+
   BaseNotificationService(this.mediator);
 
   @override
@@ -52,6 +56,7 @@ abstract class BaseNotificationService implements INotificationService {
       );
 
       Logger.info('$componentName: Habit completed successfully from notification', component: componentName);
+      onHabitCompleted?.call(habitId);
     } on BusinessException catch (e, stackTrace) {
       Logger.error(
         '[$TaskErrorIds.notificationActionFailed] $componentName: Failed to complete habit',

--- a/src/lib/infrastructure/shared/features/notification/base_notification_service.dart
+++ b/src/lib/infrastructure/shared/features/notification/base_notification_service.dart
@@ -1,12 +1,8 @@
-import 'package:acore/acore.dart';
 import 'package:mediatr/mediatr.dart';
 
-import 'package:whph/core/application/features/habits/commands/complete_habit_command.dart';
 import 'package:whph/core/application/features/settings/commands/save_setting_command.dart';
 import 'package:whph/core/application/features/settings/queries/get_setting_query.dart';
-import 'package:whph/core/application/features/tasks/commands/complete_task_command.dart';
 import 'package:whph/core/domain/features/settings/setting.dart';
-import 'package:whph/core/domain/shared/constants/task_error_ids.dart';
 import 'package:whph/core/domain/shared/utils/logger.dart';
 import 'package:whph/presentation/ui/shared/constants/setting_keys.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_notification_service.dart';
@@ -17,55 +13,7 @@ abstract class BaseNotificationService implements INotificationService {
   /// The component name to use for logging
   String get componentName;
 
-  /// Callback invoked after successful habit completion from notification.
-  /// Used to notify the UI layer to refresh habit lists.
-  void Function(String habitId)? onHabitCompleted;
-
   BaseNotificationService(this.mediator);
-
-  @override
-  Future<void> handleNotificationTaskCompletion(String taskId) async {
-    try {
-      Logger.info('$componentName: Completing task from notification: $taskId', component: componentName);
-
-      await mediator.send<CompleteTaskCommand, CompleteTaskCommandResponse>(
-        CompleteTaskCommand(id: taskId),
-      );
-
-      Logger.info('$componentName: Task completed successfully from notification', component: componentName);
-    } on BusinessException catch (e, stackTrace) {
-      Logger.error(
-        '[$TaskErrorIds.notificationActionFailed] $componentName: Failed to complete task',
-        error: e,
-        stackTrace: stackTrace,
-        component: componentName,
-      );
-    }
-  }
-
-  @override
-  Future<void> handleNotificationHabitCompletion(String habitId) async {
-    try {
-      Logger.info('$componentName: Completing habit from notification: $habitId', component: componentName);
-
-      await mediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
-        CompleteHabitCommand(
-          habitId: habitId,
-          date: DateTime.now(),
-        ),
-      );
-
-      Logger.info('$componentName: Habit completed successfully from notification', component: componentName);
-      onHabitCompleted?.call(habitId);
-    } on BusinessException catch (e, stackTrace) {
-      Logger.error(
-        '[$TaskErrorIds.notificationActionFailed] $componentName: Failed to complete habit',
-        error: e,
-        stackTrace: stackTrace,
-        component: componentName,
-      );
-    }
-  }
 
   @override
   Future<void> destroy() async {

--- a/src/lib/infrastructure/shared/features/notification/habit_notification_handler.dart
+++ b/src/lib/infrastructure/shared/features/notification/habit_notification_handler.dart
@@ -1,0 +1,39 @@
+import 'package:acore/acore.dart';
+import 'package:mediatr/mediatr.dart';
+
+import 'package:whph/core/application/features/habits/commands/complete_habit_command.dart';
+import 'package:whph/core/domain/shared/constants/task_error_ids.dart';
+import 'package:whph/core/domain/shared/utils/logger.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_habit_notification_handler.dart';
+
+class HabitNotificationHandler implements IHabitNotificationHandler {
+  final Mediator mediator;
+
+  @override
+  void Function(String habitId)? onHabitCompleted;
+
+  HabitNotificationHandler(this.mediator);
+
+  @override
+  Future<void> handleNotificationHabitCompletion(String habitId) async {
+    try {
+      Logger.info('HabitNotificationHandler: Completing habit from notification: $habitId');
+
+      await mediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+        CompleteHabitCommand(
+          habitId: habitId,
+          date: DateTime.now(),
+        ),
+      );
+
+      Logger.info('HabitNotificationHandler: Habit completed successfully from notification');
+      onHabitCompleted?.call(habitId);
+    } on BusinessException catch (e, stackTrace) {
+      Logger.error(
+        '[$TaskErrorIds.notificationActionFailed] HabitNotificationHandler: Failed to complete habit',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+}

--- a/src/lib/infrastructure/shared/features/notification/task_notification_handler.dart
+++ b/src/lib/infrastructure/shared/features/notification/task_notification_handler.dart
@@ -1,0 +1,32 @@
+import 'package:acore/acore.dart';
+import 'package:mediatr/mediatr.dart';
+
+import 'package:whph/core/application/features/tasks/commands/complete_task_command.dart';
+import 'package:whph/core/domain/shared/constants/task_error_ids.dart';
+import 'package:whph/core/domain/shared/utils/logger.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_task_notification_handler.dart';
+
+class TaskNotificationHandler implements ITaskNotificationHandler {
+  final Mediator mediator;
+
+  TaskNotificationHandler(this.mediator);
+
+  @override
+  Future<void> handleNotificationTaskCompletion(String taskId) async {
+    try {
+      Logger.info('TaskNotificationHandler: Completing task from notification: $taskId');
+
+      await mediator.send<CompleteTaskCommand, CompleteTaskCommandResponse>(
+        CompleteTaskCommand(id: taskId),
+      );
+
+      Logger.info('TaskNotificationHandler: Task completed successfully from notification');
+    } on BusinessException catch (e, stackTrace) {
+      Logger.error(
+        '[$TaskErrorIds.notificationActionFailed] TaskNotificationHandler: Failed to complete task',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+}

--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:whph/infrastructure/shared/features/notification/base_notification_service.dart';
+import 'package:whph/presentation/ui/features/habits/services/habits_service.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_notification_service.dart';
 import 'package:whph/infrastructure/shared/features/notification/abstractions/i_notification_payload_handler.dart';
 import 'package:whph/infrastructure/shared/services/desktop_startup_service.dart';
@@ -153,6 +155,15 @@ Future<void> main(List<String> args) async {
     // Set up notification handling
     final payloadHandler = tempContainer.resolve<INotificationPayloadHandler>();
     final notificationService = tempContainer.resolve<INotificationService>();
+    final habitsService = tempContainer.resolve<HabitsService>();
+
+    // Wire up UI refresh callback for habit completions from notifications
+    if (notificationService is BaseNotificationService) {
+      notificationService.onHabitCompleted = (habitId) {
+        habitsService.notifyHabitRecordAdded(habitId);
+      };
+    }
+
     NotificationPayloadService.setupNotificationListener(
       payloadHandler,
       onTaskCompletion: notificationService.handleNotificationTaskCompletion,

--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:whph/infrastructure/shared/features/notification/base_notification_service.dart';
 import 'package:whph/presentation/ui/features/habits/services/habits_service.dart';
-import 'package:whph/presentation/ui/shared/services/abstraction/i_notification_service.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_habit_notification_handler.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_task_notification_handler.dart';
 import 'package:whph/infrastructure/shared/features/notification/abstractions/i_notification_payload_handler.dart';
 import 'package:whph/infrastructure/shared/services/desktop_startup_service.dart';
 import 'package:whph/presentation/ui/app.dart';
@@ -152,32 +152,31 @@ Future<void> main(List<String> args) async {
       return;
     }
 
-    // Set up notification handling
+    // Set up notification handling with domain-specific handlers
     final payloadHandler = tempContainer.resolve<INotificationPayloadHandler>();
-    final notificationService = tempContainer.resolve<INotificationService>();
+    final taskNotificationHandler = tempContainer.resolve<ITaskNotificationHandler>();
+    final habitNotificationHandler = tempContainer.resolve<IHabitNotificationHandler>();
     final habitsService = tempContainer.resolve<HabitsService>();
 
     // Wire up UI refresh callback for habit completions from notifications
-    if (notificationService is BaseNotificationService) {
-      notificationService.onHabitCompleted = (habitId) {
-        habitsService.notifyHabitRecordAdded(habitId);
-      };
-    }
+    habitNotificationHandler.onHabitCompleted = (habitId) {
+      habitsService.notifyHabitRecordAdded(habitId);
+    };
 
     NotificationPayloadService.setupNotificationListener(
       payloadHandler,
-      onTaskCompletion: notificationService.handleNotificationTaskCompletion,
-      onHabitCompletion: notificationService.handleNotificationHabitCompletion,
+      onTaskCompletion: taskNotificationHandler.handleNotificationTaskCompletion,
+      onHabitCompletion: habitNotificationHandler.handleNotificationHabitCompletion,
     );
 
     // Process any pending task completions from notifications that arrived while app was closed
     await NotificationPayloadService.processPendingTaskCompletions(
-      notificationService.handleNotificationTaskCompletion,
+      taskNotificationHandler.handleNotificationTaskCompletion,
     );
 
     // Process any pending habit completions
     await NotificationPayloadService.processPendingHabitCompletions(
-      notificationService.handleNotificationHabitCompletion,
+      habitNotificationHandler.handleNotificationHabitCompletion,
     );
 
     // Get translation service for app wrapper

--- a/src/lib/presentation/ui/shared/models/date_filter_setting.dart
+++ b/src/lib/presentation/ui/shared/models/date_filter_setting.dart
@@ -61,11 +61,6 @@ class DateFilterSetting {
       Logger.error('$errorCode: At least one of startDate or endDate must be provided for manual date filters',
           component: 'DateFilterSetting');
       throw ArgumentError('At least one of startDate or endDate must be provided for manual date filters');
-    if (!isQuickSelection && startDate == null && endDate == null) {
-      const errorCode = 'date_filter.no_dates_provided';
-      Logger.error('$errorCode: At least one of startDate or endDate must be provided for manual date filters',
-          component: 'DateFilterSetting');
-      throw ArgumentError('At least one of startDate or endDate must be provided for manual date filters');
     }
 
     return DateFilterSetting._(
@@ -134,62 +129,72 @@ class DateFilterSetting {
 
   /// Create from JSON
   factory DateFilterSetting.fromJson(Map<String, dynamic> json) {
-    DateTime? startDate;
-    if (json['startDate'] != null) {
-      startDate = DateTime.tryParse(json['startDate'] as String);
-    }
+    try {
+      DateTime? startDate;
+      if (json['startDate'] != null) {
+        startDate = DateTime.tryParse(json['startDate'] as String);
+      }
 
-    DateTime? endDate;
-    if (json['endDate'] != null) {
-      endDate = DateTime.tryParse(json['endDate'] as String);
-    }
+      DateTime? endDate;
+      if (json['endDate'] != null) {
+        endDate = DateTime.tryParse(json['endDate'] as String);
+      }
 
-    final quickSelectionKey = json['quickSelectionKey'] as String?;
-    var isQuickSelection = json['isQuickSelection'] as bool? ?? false;
-    var isAutoRefreshEnabled = json['isAutoRefreshEnabled'] as bool? ?? false;
-    final includeNullDates = json['includeNullDates'] as bool? ?? false;
+      final quickSelectionKey = json['quickSelectionKey'] as String?;
+      var isQuickSelection = json['isQuickSelection'] as bool? ?? false;
+      var isAutoRefreshEnabled = json['isAutoRefreshEnabled'] as bool? ?? false;
+      final includeNullDates = json['includeNullDates'] as bool? ?? false;
 
-    // Fix corrupted persisted data
-    if (isQuickSelection && quickSelectionKey == null) {
-      const errorCode = 'date_filter_invalid_json';
-      Logger.warning('$errorCode: Corrupted date filter: isQuickSelection=true without key',
-          component: 'DateFilterSetting');
-      isQuickSelection = false;
-    }
+      // Fix corrupted persisted data
+      if (isQuickSelection && quickSelectionKey == null) {
+        const errorCode = 'date_filter_invalid_json';
+        Logger.warning('$errorCode: Corrupted date filter: isQuickSelection=true without key',
+            component: 'DateFilterSetting');
+        isQuickSelection = false;
+      }
 
-    if (isAutoRefreshEnabled && !isQuickSelection) {
-      const errorCode = 'date_filter_invalid_json';
-      Logger.warning('$errorCode: Corrupted date filter: isAutoRefreshEnabled=true without quick selection',
-    if (isAutoRefreshEnabled && !isQuickSelection) {
-      const errorCode = 'date_filter_invalid_json';
-      Logger.warning('$errorCode: Corrupted date filter: isAutoRefreshEnabled=true without quick selection',
-          component: 'DateFilterSetting');
-      isAutoRefreshEnabled = false;
-    }
+      if (isAutoRefreshEnabled && !isQuickSelection) {
+        const errorCode = 'date_filter_invalid_json';
+        Logger.warning('$errorCode: Corrupted date filter: isAutoRefreshEnabled=true without quick selection',
+            component: 'DateFilterSetting');
+        isAutoRefreshEnabled = false;
+      }
 
-    // Fallback to default if manual filter has no dates
-    if (!isQuickSelection && startDate == null && endDate == null) {
-      Logger.warning(
-          '[date_filter_invalid_json] Corrupted date filter: manual filter without dates, falling back to today',
-          component: 'DateFilterSetting');
+      // Fallback to default if manual filter has no dates
+      if (!isQuickSelection && startDate == null && endDate == null) {
+        Logger.warning(
+            '[date_filter_invalid_json] Corrupted date filter: manual filter without dates, falling back to today',
+            component: 'DateFilterSetting');
+        final now = DateTime.now();
+        return DateFilterSetting.quickSelection(
+          key: 'today',
+          startDate: DateTime(now.year, now.month, now.day),
+          endDate: DateTime(now.year, now.month, now.day, 23, 59, 59),
+          isAutoRefreshEnabled: true,
+          includeNullDates: includeNullDates,
+        );
+      }
+
+      return DateFilterSetting(
+        quickSelectionKey: quickSelectionKey,
+        startDate: startDate,
+        endDate: endDate,
+        isQuickSelection: isQuickSelection,
+        isAutoRefreshEnabled: isAutoRefreshEnabled,
+        includeNullDates: includeNullDates,
+      );
+    } catch (e, stackTrace) {
+      Logger.error('[date_filter_json_parse_failed] Failed to parse DateFilterSetting from JSON, falling back to today',
+          component: 'DateFilterSetting', error: e, stackTrace: stackTrace);
+
       final now = DateTime.now();
       return DateFilterSetting.quickSelection(
         key: 'today',
         startDate: DateTime(now.year, now.month, now.day),
         endDate: DateTime(now.year, now.month, now.day, 23, 59, 59),
         isAutoRefreshEnabled: true,
-        includeNullDates: includeNullDates,
       );
     }
-
-    return DateFilterSetting(
-      quickSelectionKey: quickSelectionKey,
-      startDate: startDate,
-      endDate: endDate,
-      isQuickSelection: isQuickSelection,
-      isAutoRefreshEnabled: isAutoRefreshEnabled,
-      includeNullDates: includeNullDates,
-    );
   }
 
   /// Convert to JSON

--- a/src/lib/presentation/ui/shared/models/date_filter_setting.dart
+++ b/src/lib/presentation/ui/shared/models/date_filter_setting.dart
@@ -61,6 +61,11 @@ class DateFilterSetting {
       Logger.error('$errorCode: At least one of startDate or endDate must be provided for manual date filters',
           component: 'DateFilterSetting');
       throw ArgumentError('At least one of startDate or endDate must be provided for manual date filters');
+    if (!isQuickSelection && startDate == null && endDate == null) {
+      const errorCode = 'date_filter.no_dates_provided';
+      Logger.error('$errorCode: At least one of startDate or endDate must be provided for manual date filters',
+          component: 'DateFilterSetting');
+      throw ArgumentError('At least one of startDate or endDate must be provided for manual date filters');
     }
 
     return DateFilterSetting._(
@@ -152,6 +157,9 @@ class DateFilterSetting {
       isQuickSelection = false;
     }
 
+    if (isAutoRefreshEnabled && !isQuickSelection) {
+      const errorCode = 'date_filter_invalid_json';
+      Logger.warning('$errorCode: Corrupted date filter: isAutoRefreshEnabled=true without quick selection',
     if (isAutoRefreshEnabled && !isQuickSelection) {
       const errorCode = 'date_filter_invalid_json';
       Logger.warning('$errorCode: Corrupted date filter: isAutoRefreshEnabled=true without quick selection',

--- a/src/lib/presentation/ui/shared/services/abstraction/i_habit_notification_handler.dart
+++ b/src/lib/presentation/ui/shared/services/abstraction/i_habit_notification_handler.dart
@@ -1,0 +1,5 @@
+abstract class IHabitNotificationHandler {
+  void Function(String habitId)? onHabitCompleted;
+
+  Future<void> handleNotificationHabitCompletion(String habitId);
+}

--- a/src/lib/presentation/ui/shared/services/abstraction/i_notification_service.dart
+++ b/src/lib/presentation/ui/shared/services/abstraction/i_notification_service.dart
@@ -36,16 +36,6 @@ abstract class INotificationService {
   /// Request permission to display notifications from the user
   /// Returns true if permission is granted, false otherwise
   Future<bool> requestPermission();
-
-  /// Handle task completion from notification action button
-  /// Mobile platforms (Android/iOS) should implement this to process task completions
-  /// Desktop platforms provide a no-op implementation
-  Future<void> handleNotificationTaskCompletion(String taskId);
-
-  /// Handle habit completion from notification action button
-  /// Mobile platforms (Android/iOS) should implement this to process habit completions
-  /// Desktop platforms provide a no-op implementation
-  Future<void> handleNotificationHabitCompletion(String habitId);
 }
 
 class NotificationAction {

--- a/src/lib/presentation/ui/shared/services/abstraction/i_task_notification_handler.dart
+++ b/src/lib/presentation/ui/shared/services/abstraction/i_task_notification_handler.dart
@@ -1,0 +1,3 @@
+abstract class ITaskNotificationHandler {
+  Future<void> handleNotificationTaskCompletion(String taskId);
+}

--- a/src/test/core/application/features/habits/commands/complete_habit_command_handler_test.dart
+++ b/src/test/core/application/features/habits/commands/complete_habit_command_handler_test.dart
@@ -1,0 +1,271 @@
+import 'package:acore/acore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whph/core/application/features/habits/commands/complete_habit_command.dart';
+import 'package:whph/core/application/features/habits/services/i_habit_record_repository.dart';
+import 'package:whph/core/application/features/habits/services/i_habit_repository.dart';
+import 'package:whph/core/application/features/habits/services/i_habit_time_record_repository.dart';
+import 'package:whph/core/domain/features/habits/habit.dart';
+import 'package:whph/core/domain/features/habits/habit_record.dart';
+import 'package:whph/core/domain/features/habits/habit_record_status.dart';
+import 'package:whph/core/domain/features/habits/habit_time_record.dart';
+import 'package:whph/infrastructure/persistence/shared/contexts/drift/drift_app_context.dart';
+
+class FakeHabitRepository extends Fake implements IHabitRepository {
+  Habit? _habit;
+
+  void setHabit(Habit habit) => _habit = habit;
+
+  @override
+  Future<Habit?> getById(String id, {bool includeDeleted = false}) async => _habit;
+}
+
+class FakeHabitRecordRepository extends Fake implements IHabitRecordRepository {
+  final List<HabitRecord> records = [];
+  int addCount = 0;
+  int deleteCount = 0;
+
+  @override
+  Future<PaginatedList<HabitRecord>> getListByHabitIdAndRangeDate(
+    String habitId,
+    DateTime startDate,
+    DateTime endDate,
+    int pageIndex,
+    int pageSize,
+  ) async {
+    final matchingRecords = records
+        .where((record) =>
+            record.habitId == habitId &&
+            !record.occurredAt.isBefore(startDate) &&
+            !record.occurredAt.isAfter(endDate))
+        .toList();
+    return PaginatedList(
+      items: matchingRecords,
+      totalItemCount: matchingRecords.length,
+      pageIndex: pageIndex,
+      pageSize: pageSize,
+    );
+  }
+
+  @override
+  Future<void> add(HabitRecord record) async {
+    addCount++;
+    records.add(record);
+  }
+
+  @override
+  Future<void> delete(HabitRecord record) async {
+    deleteCount++;
+    records.removeWhere((existingRecord) => existingRecord.id == record.id);
+  }
+}
+
+class FakeHabitTimeRecordRepository extends Fake implements IHabitTimeRecordRepository {
+  final List<HabitTimeRecord> records = [];
+  int addCount = 0;
+  int updateCount = 0;
+
+  @override
+  Future<HabitTimeRecord?> getFirst(CustomWhereFilter filter, {bool includeDeleted = false}) async {
+    return records.firstOrNull;
+  }
+
+  @override
+  Future<void> add(HabitTimeRecord record) async {
+    addCount++;
+    records.add(record);
+  }
+
+  @override
+  Future<void> update(HabitTimeRecord record) async {
+    updateCount++;
+    final index = records.indexWhere((existingRecord) => existingRecord.id == record.id);
+    if (index >= 0) {
+      records[index] = record;
+    }
+  }
+
+  @override
+  Future<List<HabitTimeRecord>> getByHabitIdAndDateRange(String habitId, DateTime start, DateTime end) async {
+    return records.where((record) => record.habitId == habitId).toList();
+  }
+}
+
+void main() {
+  late CompleteHabitCommandHandler handler;
+  late FakeHabitRepository habitRepository;
+  late FakeHabitRecordRepository habitRecordRepository;
+  late FakeHabitTimeRecordRepository habitTimeRecordRepository;
+
+  setUp(() {
+    AppDatabase.resetInstance();
+    AppDatabase.setInstanceForTesting(AppDatabase.forTesting());
+
+    habitRepository = FakeHabitRepository();
+    habitRecordRepository = FakeHabitRecordRepository();
+    habitTimeRecordRepository = FakeHabitTimeRecordRepository();
+
+    handler = CompleteHabitCommandHandler(
+      habitRepository: habitRepository,
+      habitRecordRepository: habitRecordRepository,
+      habitTimeRecordRepository: habitTimeRecordRepository,
+    );
+  });
+
+  tearDown(() async {
+    await AppDatabase.instance().close();
+    AppDatabase.resetInstance();
+  });
+
+  group('single occurrence habit', () {
+    const habitId = 'habit-single';
+    final date = DateTime(2026, 1, 11, 9);
+
+    setUp(() {
+      habitRepository.setHabit(Habit(
+        id: habitId,
+        createdDate: DateTime.now(),
+        name: 'Single Habit',
+        description: 'Test',
+        hasGoal: false,
+      ));
+    });
+
+    test('adds a complete record when there is no record for the day', () async {
+      await handler.call(CompleteHabitCommand(habitId: habitId, date: date));
+
+      expect(habitRecordRepository.records.length, 1);
+      expect(habitRecordRepository.records.first.status, HabitRecordStatus.complete);
+      expect(habitRecordRepository.addCount, 1);
+    });
+
+    test('keeps an existing complete record unchanged', () async {
+      final existingRecord = HabitRecord(
+        id: 'record-1',
+        habitId: habitId,
+        occurredAt: date.toUtc(),
+        status: HabitRecordStatus.complete,
+        createdDate: DateTime.now(),
+      );
+      habitRecordRepository.records.add(existingRecord);
+
+      await handler.call(CompleteHabitCommand(habitId: habitId, date: date));
+
+      expect(habitRecordRepository.records, [existingRecord]);
+      expect(habitRecordRepository.addCount, 0);
+      expect(habitRecordRepository.deleteCount, 0);
+    });
+
+    test('replaces not done with complete', () async {
+      habitRecordRepository.records.add(HabitRecord(
+        id: 'record-1',
+        habitId: habitId,
+        occurredAt: date.toUtc(),
+        status: HabitRecordStatus.notDone,
+        createdDate: DateTime.now(),
+      ));
+
+      await handler.call(CompleteHabitCommand(habitId: habitId, date: date));
+
+      expect(habitRecordRepository.records.length, 1);
+      expect(habitRecordRepository.records.first.status, HabitRecordStatus.complete);
+      expect(habitRecordRepository.addCount, 1);
+      expect(habitRecordRepository.deleteCount, 1);
+    });
+  });
+
+  group('multi occurrence habit', () {
+    const habitId = 'habit-multi';
+    final date = DateTime(2026, 1, 11, 9);
+
+    setUp(() {
+      habitRepository.setHabit(Habit(
+        id: habitId,
+        createdDate: DateTime.now(),
+        name: 'Multi Habit',
+        description: 'Test',
+        hasGoal: true,
+        dailyTarget: 2,
+        periodDays: 1,
+        targetFrequency: 1,
+      ));
+    });
+
+    test('adds one complete record when target is not met', () async {
+      habitRecordRepository.records.add(HabitRecord(
+        id: 'record-1',
+        habitId: habitId,
+        occurredAt: date.toUtc(),
+        status: HabitRecordStatus.complete,
+        createdDate: DateTime.now(),
+      ));
+
+      await handler.call(CompleteHabitCommand(habitId: habitId, date: date));
+
+      expect(habitRecordRepository.records.length, 2);
+      expect(habitRecordRepository.records.every((record) => record.status == HabitRecordStatus.complete), true);
+      expect(habitRecordRepository.addCount, 1);
+    });
+
+    test('does not add another record when target is already met', () async {
+      habitRecordRepository.records.addAll([
+        HabitRecord(
+          id: 'record-1',
+          habitId: habitId,
+          occurredAt: date.toUtc(),
+          status: HabitRecordStatus.complete,
+          createdDate: DateTime.now(),
+        ),
+        HabitRecord(
+          id: 'record-2',
+          habitId: habitId,
+          occurredAt: date.toUtc(),
+          status: HabitRecordStatus.complete,
+          createdDate: DateTime.now(),
+        ),
+      ]);
+
+      await handler.call(CompleteHabitCommand(habitId: habitId, date: date));
+
+      expect(habitRecordRepository.records.length, 2);
+      expect(habitRecordRepository.addCount, 0);
+      expect(habitRecordRepository.deleteCount, 0);
+    });
+
+    test('clears not done and adds complete when target is not met', () async {
+      habitRecordRepository.records.add(HabitRecord(
+        id: 'record-1',
+        habitId: habitId,
+        occurredAt: date.toUtc(),
+        status: HabitRecordStatus.notDone,
+        createdDate: DateTime.now(),
+      ));
+
+      await handler.call(CompleteHabitCommand(habitId: habitId, date: date));
+
+      expect(habitRecordRepository.records.length, 1);
+      expect(habitRecordRepository.records.first.status, HabitRecordStatus.complete);
+      expect(habitRecordRepository.addCount, 1);
+      expect(habitRecordRepository.deleteCount, 1);
+    });
+  });
+
+  test('adds estimated time only when a new complete record is added', () async {
+    const habitId = 'habit-estimated';
+    final date = DateTime(2026, 1, 11, 9);
+    habitRepository.setHabit(Habit(
+      id: habitId,
+      createdDate: DateTime.now(),
+      name: 'Estimated Habit',
+      description: 'Test',
+      estimatedTime: 15,
+      hasGoal: false,
+    ));
+
+    await handler.call(CompleteHabitCommand(habitId: habitId, date: date));
+    await handler.call(CompleteHabitCommand(habitId: habitId, date: date));
+
+    expect(habitRecordRepository.records.length, 1);
+    expect(habitTimeRecordRepository.records.length, 1);
+    expect(habitTimeRecordRepository.records.first.duration, 15 * 60);
+  });
+}

--- a/src/test/core/application/features/habits/commands/complete_habit_command_handler_test.dart
+++ b/src/test/core/application/features/habits/commands/complete_habit_command_handler_test.dart
@@ -7,6 +7,7 @@ import 'package:whph/core/application/features/habits/services/i_habit_time_reco
 import 'package:whph/core/domain/features/habits/habit.dart';
 import 'package:whph/core/domain/features/habits/habit_record.dart';
 import 'package:whph/core/domain/features/habits/habit_record_status.dart';
+import 'package:whph/core/application/features/habits/services/habit_record_operations_service.dart';
 import 'package:whph/core/domain/features/habits/habit_time_record.dart';
 import 'package:whph/infrastructure/persistence/shared/contexts/drift/drift_app_context.dart';
 
@@ -34,9 +35,7 @@ class FakeHabitRecordRepository extends Fake implements IHabitRecordRepository {
   ) async {
     final matchingRecords = records
         .where((record) =>
-            record.habitId == habitId &&
-            !record.occurredAt.isBefore(startDate) &&
-            !record.occurredAt.isAfter(endDate))
+            record.habitId == habitId && !record.occurredAt.isBefore(startDate) && !record.occurredAt.isAfter(endDate))
         .toList();
     return PaginatedList(
       items: matchingRecords,
@@ -104,10 +103,15 @@ void main() {
     habitRecordRepository = FakeHabitRecordRepository();
     habitTimeRecordRepository = FakeHabitTimeRecordRepository();
 
+    final operationsService = HabitRecordOperationsService(
+      habitRecordRepository: habitRecordRepository,
+      habitTimeRecordRepository: habitTimeRecordRepository,
+    );
+
     handler = CompleteHabitCommandHandler(
       habitRepository: habitRepository,
       habitRecordRepository: habitRecordRepository,
-      habitTimeRecordRepository: habitTimeRecordRepository,
+      operationsService: operationsService,
     );
   });
 

--- a/src/test/core/application/features/habits/commands/complete_habit_command_handler_test.dart
+++ b/src/test/core/application/features/habits/commands/complete_habit_command_handler_test.dart
@@ -12,12 +12,12 @@ import 'package:whph/core/domain/features/habits/habit_time_record.dart';
 import 'package:whph/infrastructure/persistence/shared/contexts/drift/drift_app_context.dart';
 
 class FakeHabitRepository extends Fake implements IHabitRepository {
-  Habit? _habit;
+  final Map<String, Habit> _habits = {};
 
-  void setHabit(Habit habit) => _habit = habit;
+  void setHabit(Habit habit) => _habits[habit.id] = habit;
 
   @override
-  Future<Habit?> getById(String id, {bool includeDeleted = false}) async => _habit;
+  Future<Habit?> getById(String id, {bool includeDeleted = false}) async => _habits[id];
 }
 
 class FakeHabitRecordRepository extends Fake implements IHabitRecordRepository {
@@ -62,9 +62,11 @@ class FakeHabitTimeRecordRepository extends Fake implements IHabitTimeRecordRepo
   final List<HabitTimeRecord> records = [];
   int addCount = 0;
   int updateCount = 0;
+  int deleteCount = 0;
 
   @override
   Future<HabitTimeRecord?> getFirst(CustomWhereFilter filter, {bool includeDeleted = false}) async {
+    // A simplified fake implementation.
     return records.firstOrNull;
   }
 
@@ -84,8 +86,20 @@ class FakeHabitTimeRecordRepository extends Fake implements IHabitTimeRecordRepo
   }
 
   @override
+  Future<void> delete(HabitTimeRecord record) async {
+    deleteCount++;
+    records.removeWhere((existingRecord) => existingRecord.id == record.id);
+  }
+
+  @override
   Future<List<HabitTimeRecord>> getByHabitIdAndDateRange(String habitId, DateTime start, DateTime end) async {
-    return records.where((record) => record.habitId == habitId).toList();
+    return records
+        .where((record) =>
+            record.habitId == habitId &&
+            record.occurredAt != null &&
+            !record.occurredAt!.isBefore(start) &&
+            !record.occurredAt!.isAfter(end))
+        .toList();
   }
 }
 
@@ -118,6 +132,16 @@ void main() {
   tearDown(() async {
     await AppDatabase.instance().close();
     AppDatabase.resetInstance();
+  });
+
+  test('throws BusinessException when habit is not found', () async {
+    const habitId = 'non-existent-habit';
+    final date = DateTime(2026, 1, 11, 9);
+
+    expect(
+      () => handler.call(CompleteHabitCommand(habitId: habitId, date: date)),
+      throwsA(isA<BusinessException>()),
+    );
   });
 
   group('single occurrence habit', () {
@@ -159,7 +183,16 @@ void main() {
       expect(habitRecordRepository.deleteCount, 0);
     });
 
-    test('replaces not done with complete', () async {
+    test('replaces not done with complete and adds estimated time', () async {
+      habitRepository.setHabit(Habit(
+        id: habitId,
+        createdDate: DateTime.now(),
+        name: 'Single Habit Estimated',
+        description: 'Test',
+        estimatedTime: 20,
+        hasGoal: false,
+      ));
+
       habitRecordRepository.records.add(HabitRecord(
         id: 'record-1',
         habitId: habitId,
@@ -172,8 +205,8 @@ void main() {
 
       expect(habitRecordRepository.records.length, 1);
       expect(habitRecordRepository.records.first.status, HabitRecordStatus.complete);
-      expect(habitRecordRepository.addCount, 1);
-      expect(habitRecordRepository.deleteCount, 1);
+      expect(habitTimeRecordRepository.records.length, 1);
+      expect(habitTimeRecordRepository.records.first.duration, 20 * 60);
     });
   });
 

--- a/src/test/core/application/features/habits/commands/toggle_habit_completion_command_handler_test.dart
+++ b/src/test/core/application/features/habits/commands/toggle_habit_completion_command_handler_test.dart
@@ -10,6 +10,7 @@ import 'package:whph/core/domain/features/habits/habit_record_status.dart';
 import 'package:whph/core/domain/features/settings/setting.dart';
 import 'package:whph/presentation/ui/shared/constants/setting_keys.dart';
 import 'package:acore/acore.dart';
+import 'package:whph/core/application/features/habits/services/habit_record_operations_service.dart';
 import 'package:whph/core/domain/features/habits/habit_time_record.dart';
 import 'package:whph/infrastructure/persistence/shared/contexts/drift/drift_app_context.dart';
 
@@ -96,11 +97,16 @@ void main() {
     fakeHabitTimeRecordRepository = FakeHabitTimeRecordRepository();
     fakeSettingRepository = FakeSettingRepository();
 
+    final operationsService = HabitRecordOperationsService(
+      habitRecordRepository: fakeHabitRecordRepository,
+      habitTimeRecordRepository: fakeHabitTimeRecordRepository,
+    );
+
     handler = ToggleHabitCompletionCommandHandler(
       habitRepository: fakeHabitRepository,
       habitRecordRepository: fakeHabitRecordRepository,
-      habitTimeRecordRepository: fakeHabitTimeRecordRepository,
       settingsRepository: fakeSettingRepository,
+      operationsService: operationsService,
     );
   });
 

--- a/src/test/infrastructure/mobile/features/notification/mobile_notification_service_test.dart
+++ b/src/test/infrastructure/mobile/features/notification/mobile_notification_service_test.dart
@@ -4,6 +4,7 @@ import 'package:mockito/mockito.dart';
 import 'package:mediatr/mediatr.dart';
 import 'package:whph/core/application/features/tasks/commands/complete_task_command.dart';
 import 'package:whph/infrastructure/mobile/features/notification/mobile_notification_service.dart';
+import 'package:whph/infrastructure/shared/features/notification/task_notification_handler.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:whph/core/application/features/settings/queries/get_setting_query.dart';
 import 'package:whph/core/domain/features/settings/setting.dart';
@@ -157,7 +158,7 @@ void main() {
     });
 
     // Existing tests...
-    group('handleNotificationTaskCompletion', () {
+    group('TaskNotificationHandler', () {
       test('should send CompleteTaskCommand when valid task ID is provided', () async {
         // Arrange
         final taskId = 'test-task-id';
@@ -166,10 +167,10 @@ void main() {
           argThat(isA<CompleteTaskCommand>()),
         )).thenAnswer((_) async => CompleteTaskCommandResponse(taskId: taskId));
 
-        service = MobileNotificationService(mockMediator);
+        final handler = TaskNotificationHandler(mockMediator);
 
         // Act
-        await service.handleNotificationTaskCompletion(taskId);
+        await handler.handleNotificationTaskCompletion(taskId);
 
         // Assert
         verify(mockMediator.send<CompleteTaskCommand, CompleteTaskCommandResponse>(

--- a/src/test/infrastructure/shared/features/notification/notification_handlers_test.dart
+++ b/src/test/infrastructure/shared/features/notification/notification_handlers_test.dart
@@ -113,7 +113,8 @@ void main() {
           argThat(isA<CompleteHabitCommand>().having(
             (cmd) => cmd.date,
             'date',
-            predicate<DateTime>((date) => date.isAfter(beforeCall.subtract(const Duration(seconds: 1))) &&
+            predicate<DateTime>((date) =>
+                date.isAfter(beforeCall.subtract(const Duration(seconds: 1))) &&
                 date.isBefore(afterCall.add(const Duration(seconds: 1)))),
           )),
         )).called(1);

--- a/src/test/infrastructure/shared/features/notification/notification_handlers_test.dart
+++ b/src/test/infrastructure/shared/features/notification/notification_handlers_test.dart
@@ -1,0 +1,198 @@
+import 'package:acore/acore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mediatr/mediatr.dart';
+
+import 'package:whph/core/application/features/habits/commands/complete_habit_command.dart';
+import 'package:whph/core/application/features/tasks/commands/complete_task_command.dart';
+import 'package:whph/infrastructure/shared/features/notification/habit_notification_handler.dart';
+import 'package:whph/infrastructure/shared/features/notification/task_notification_handler.dart';
+
+import 'notification_handlers_test.mocks.dart';
+
+@GenerateMocks([Mediator])
+void main() {
+  group('TaskNotificationHandler', () {
+    late MockMediator mockMediator;
+    late TaskNotificationHandler handler;
+
+    setUp(() {
+      mockMediator = MockMediator();
+      handler = TaskNotificationHandler(mockMediator);
+    });
+
+    group('handleNotificationTaskCompletion', () {
+      test('should send CompleteTaskCommand with correct task ID', () async {
+        final taskId = 'task-123';
+
+        when(mockMediator.send<CompleteTaskCommand, CompleteTaskCommandResponse>(
+          argThat(isA<CompleteTaskCommand>()),
+        )).thenAnswer((_) async => CompleteTaskCommandResponse(taskId: taskId));
+
+        await handler.handleNotificationTaskCompletion(taskId);
+
+        verify(mockMediator.send<CompleteTaskCommand, CompleteTaskCommandResponse>(
+          argThat(isA<CompleteTaskCommand>().having(
+            (cmd) => cmd.id,
+            'id',
+            taskId,
+          )),
+        )).called(1);
+      });
+
+      test('should not throw when mediator throws BusinessException', () async {
+        final taskId = 'task-456';
+
+        when(mockMediator.send<CompleteTaskCommand, CompleteTaskCommandResponse>(
+          any,
+        )).thenThrow(BusinessException('Task not found', 'task-not-found'));
+
+        expect(
+          () async => handler.handleNotificationTaskCompletion(taskId),
+          returnsNormally,
+        );
+      });
+
+      test('should propagate non-BusinessException errors', () async {
+        final taskId = 'task-789';
+
+        when(mockMediator.send<CompleteTaskCommand, CompleteTaskCommandResponse>(
+          any,
+        )).thenThrow(Exception('Unexpected error'));
+
+        expect(
+          () async => handler.handleNotificationTaskCompletion(taskId),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+  });
+
+  group('HabitNotificationHandler', () {
+    late MockMediator mockMediator;
+    late HabitNotificationHandler handler;
+
+    setUp(() {
+      mockMediator = MockMediator();
+      handler = HabitNotificationHandler(mockMediator);
+    });
+
+    group('handleNotificationHabitCompletion', () {
+      test('should send CompleteHabitCommand with correct habit ID', () async {
+        final habitId = 'habit-123';
+
+        when(mockMediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+          argThat(isA<CompleteHabitCommand>()),
+        )).thenAnswer((_) async => CompleteHabitCommandResponse());
+
+        await handler.handleNotificationHabitCompletion(habitId);
+
+        verify(mockMediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+          argThat(isA<CompleteHabitCommand>().having(
+            (cmd) => cmd.habitId,
+            'habitId',
+            habitId,
+          )),
+        )).called(1);
+      });
+
+      test('should send CompleteHabitCommand with current date', () async {
+        final habitId = 'habit-456';
+        final beforeCall = DateTime.now();
+
+        when(mockMediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+          any,
+        )).thenAnswer((_) async => CompleteHabitCommandResponse());
+
+        await handler.handleNotificationHabitCompletion(habitId);
+
+        final afterCall = DateTime.now();
+
+        verify(mockMediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+          argThat(isA<CompleteHabitCommand>().having(
+            (cmd) => cmd.date,
+            'date',
+            predicate<DateTime>((date) => date.isAfter(beforeCall.subtract(const Duration(seconds: 1))) &&
+                date.isBefore(afterCall.add(const Duration(seconds: 1)))),
+          )),
+        )).called(1);
+      });
+
+      test('should call onHabitCompleted callback after successful completion', () async {
+        final habitId = 'habit-789';
+        String? callbackHabitId;
+
+        when(mockMediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+          any,
+        )).thenAnswer((_) async => CompleteHabitCommandResponse());
+
+        handler.onHabitCompleted = (id) {
+          callbackHabitId = id;
+        };
+
+        await handler.handleNotificationHabitCompletion(habitId);
+
+        expect(callbackHabitId, equals(habitId));
+      });
+
+      test('should not call onHabitCompleted when callback is null', () async {
+        final habitId = 'habit-012';
+
+        when(mockMediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+          any,
+        )).thenAnswer((_) async => CompleteHabitCommandResponse());
+
+        handler.onHabitCompleted = null;
+
+        expect(
+          () async => handler.handleNotificationHabitCompletion(habitId),
+          returnsNormally,
+        );
+      });
+
+      test('should not throw when mediator throws BusinessException', () async {
+        final habitId = 'habit-345';
+
+        when(mockMediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+          any,
+        )).thenThrow(BusinessException('Habit not found', 'habit-not-found'));
+
+        expect(
+          () async => handler.handleNotificationHabitCompletion(habitId),
+          returnsNormally,
+        );
+      });
+
+      test('should not call onHabitCompleted when BusinessException is thrown', () async {
+        final habitId = 'habit-678';
+        var callbackCalled = false;
+
+        when(mockMediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+          any,
+        )).thenThrow(BusinessException('Habit not found', 'habit-not-found'));
+
+        handler.onHabitCompleted = (_) {
+          callbackCalled = true;
+        };
+
+        await handler.handleNotificationHabitCompletion(habitId);
+
+        expect(callbackCalled, isFalse);
+      });
+
+      test('should propagate non-BusinessException errors', () async {
+        final habitId = 'habit-901';
+
+        when(mockMediator.send<CompleteHabitCommand, CompleteHabitCommandResponse>(
+          any,
+        )).thenThrow(Exception('Unexpected error'));
+
+        expect(
+          () async => handler.handleNotificationHabitCompletion(habitId),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
### 🚀 Motivation and Context

This PR fixes an Android habit notification regression where tapping the notification `Done` action could toggle an already-completed habit back to incomplete. The notification action is user-facing as an explicit completion command, so it should behave like task notification completion: idempotently mark the item as done rather than cycling through habit states.

### ⚙️ Implementation Details

**Core Changes:**
- Added `CompleteHabitCommand` for explicit, idempotent habit completion
- Registered `CompleteHabitCommandHandler` in the habits feature registration
- Updated notification habit completion handling to use `CompleteHabitCommand` instead of `ToggleHabitCompletionCommand`
- Added command handler tests for single-occurrence and multi-occurrence habit completion behavior

**Technical Approach:**
- Keeps UI/widget habit interactions on the existing toggle semantics
- Separates notification `Done` behavior from habit state cycling
- Preserves completed habits when completion is requested again
- Replaces `notDone`/missing single-day records with `complete`
- Adds one completion for multi-occurrence habits only when the daily target has not been met
- Avoids duplicate estimated time records by only adding estimated time when a new complete record is created

**Bug Fixed:**
- Prevents Android notification `Done` from making an already-completed habit incomplete (fixes #277)

### 📋 Checklist for Reviewer

- [x] Notification completion no longer uses toggle semantics
- [x] Added focused command handler coverage for the new completion behavior
- [x] Tests passed locally (1846 passed, 1 pre-existing failure in unrelated test)

### 🔗 Related

- Aligns habit notification completion semantics with task notification completion
- Keeps existing habit UI toggle behavior unchanged