### PR TITLE
fix(tasks): stop spurious not-found overlay on tag removal

### DIFF
--- a/src/lib/core/application/features/tasks/commands/remove_task_tag_command.dart
+++ b/src/lib/core/application/features/tasks/commands/remove_task_tag_command.dart
@@ -1,8 +1,6 @@
 import 'package:mediatr/mediatr.dart';
 import 'package:whph/core/application/features/tasks/services/abstraction/i_task_tag_repository.dart';
-import 'package:acore/acore.dart';
 import 'package:whph/core/domain/features/tasks/task_tag.dart';
-import 'package:whph/core/application/features/tasks/constants/task_translation_keys.dart';
 
 class RemoveTaskTagCommand implements IRequest<RemoveTaskTagCommandResponse> {
   String id;
@@ -25,15 +23,21 @@ class RemoveTaskTagCommandHandler implements IRequestHandler<RemoveTaskTagComman
 
   RemoveTaskTagCommandHandler({required ITaskTagRepository taskTagRepository}) : _taskTagRepository = taskTagRepository;
 
+  /// Removing a tag that is already gone (not found, or already soft-deleted)
+  /// achieves the caller's desired end state, so it is treated as a
+  /// successful no-op rather than an error. This keeps repeated/concurrent
+  /// removal requests for the same association idempotent instead of
+  /// surfacing a spurious "not found" notification for an operation that
+  /// effectively already succeeded.
   @override
   Future<RemoveTaskTagCommandResponse> call(RemoveTaskTagCommand request) async {
     TaskTag? taskTag = await _taskTagRepository.getById(request.id);
-    if (taskTag == null) {
-      throw BusinessException('Task tag not found', TaskTranslationKeys.taskTagNotFoundError);
+    if (taskTag == null || taskTag.deletedDate != null) {
+      return RemoveTaskTagCommandResponse(
+        id: request.id,
+      );
     }
-    if (taskTag.deletedDate != null) {
-      throw BusinessException('Task tag already deleted', TaskTranslationKeys.taskTagAlreadyDeletedError);
-    }
+
     await _taskTagRepository.delete(taskTag);
 
     return RemoveTaskTagCommandResponse(

--- a/src/lib/presentation/ui/features/tasks/components/task_details_content/controllers/task_details_controller.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_details_content/controllers/task_details_controller.dart
@@ -401,6 +401,8 @@ class TaskDetailsController extends ChangeNotifier {
   }
 
   // Tag operations
+  bool _isProcessingTagChanges = false;
+
   Future<bool> addTag(String tagId, BuildContext context) async {
     if (!context.mounted) return false;
     final result = await AsyncErrorHandler.execute<AddTaskTagCommandResponse>(
@@ -419,6 +421,11 @@ class TaskDetailsController extends ChangeNotifier {
   }
 
   Future<bool> removeTag(String id, BuildContext context) async {
+    // Removed optimistically so a concurrent diff (e.g. a second tag-change
+    // request arriving before this one's loadTaskTags finishes) can't
+    // re-target the same association and re-send the same removal command.
+    _taskTags?.items.removeWhere((taskTag) => taskTag.id == id);
+
     final result = await AsyncErrorHandler.execute<RemoveTaskTagCommandResponse>(
       context: context,
       errorMessage: _translationService.translate(TaskTranslationKeys.removeTagError),
@@ -438,32 +445,38 @@ class TaskDetailsController extends ChangeNotifier {
     List<DropdownOption<String>> tagOptions,
     BuildContext context,
   ) async {
-    if (_taskTags == null) return;
+    if (_taskTags == null || _isProcessingTagChanges) return;
+    _isProcessingTagChanges = true;
 
-    final tagOptionsToAdd =
-        tagOptions.where((tagOption) => !_taskTags!.items.any((taskTag) => taskTag.tagId == tagOption.value)).toList();
-    final tagsToRemove =
-        _taskTags!.items.where((taskTag) => !tagOptions.map((tag) => tag.value).contains(taskTag.tagId)).toList();
+    try {
+      final tagOptionsToAdd = tagOptions
+          .where((tagOption) => !_taskTags!.items.any((taskTag) => taskTag.tagId == tagOption.value))
+          .toList();
+      final tagsToRemove =
+          _taskTags!.items.where((taskTag) => !tagOptions.map((tag) => tag.value).contains(taskTag.tagId)).toList();
 
-    for (final tagOption in tagOptionsToAdd) {
-      if (!context.mounted) return;
-      await addTag(tagOption.value, context);
-    }
+      for (final tagOption in tagOptionsToAdd) {
+        if (!context.mounted) return;
+        await addTag(tagOption.value, context);
+      }
 
-    for (final taskTag in tagsToRemove) {
-      if (!context.mounted) return;
-      await removeTag(taskTag.id, context);
-    }
+      for (final taskTag in tagsToRemove) {
+        if (!context.mounted) return;
+        await removeTag(taskTag.id, context);
+      }
 
-    if (tagOptions.isNotEmpty) {
-      final tagOrders = {for (int i = 0; i < tagOptions.length; i++) tagOptions[i].value: i};
-      final orderCommand = UpdateTaskTagsOrderCommand(taskId: _task!.id, tagOrders: tagOrders);
-      await _mediator.send(orderCommand);
-    }
+      if (tagOptions.isNotEmpty) {
+        final tagOrders = {for (int i = 0; i < tagOptions.length; i++) tagOptions[i].value: i};
+        final orderCommand = UpdateTaskTagsOrderCommand(taskId: _task!.id, tagOrders: tagOrders);
+        await _mediator.send(orderCommand);
+      }
 
-    if (tagOptionsToAdd.isNotEmpty || tagsToRemove.isNotEmpty || tagOptions.isNotEmpty) {
-      await loadTaskTags(_task!.id);
-      _tasksService.notifyTaskUpdated(_task!.id);
+      if (tagOptionsToAdd.isNotEmpty || tagsToRemove.isNotEmpty || tagOptions.isNotEmpty) {
+        await loadTaskTags(_task!.id);
+        _tasksService.notifyTaskUpdated(_task!.id);
+      }
+    } finally {
+      _isProcessingTagChanges = false;
     }
   }
 

--- a/src/test/core/application/features/tasks/commands/remove_task_tag_command_test.dart
+++ b/src/test/core/application/features/tasks/commands/remove_task_tag_command_test.dart
@@ -4,7 +4,6 @@ import 'package:mockito/mockito.dart';
 import 'package:whph/core/application/features/tasks/commands/remove_task_tag_command.dart';
 import 'package:whph/core/application/features/tasks/services/abstraction/i_task_tag_repository.dart';
 import 'package:whph/core/domain/features/tasks/task_tag.dart';
-import 'package:acore/acore.dart';
 
 import 'remove_task_tag_command_test.mocks.dart';
 
@@ -46,27 +45,28 @@ void main() {
       verify(mockTaskTagRepository.delete(existingTaskTag)).called(1);
     });
 
-    // Test handling of non-existent task tag
-    test('should throw BusinessException when task tag does not exist', () async {
+    // Test handling of non-existent task tag: removing something that is
+    // already gone achieves the caller's desired end state, so this is a
+    // successful no-op rather than an error (prevents spurious "not found"
+    // notifications when a removal is retried/raced).
+    test('should return successfully as a no-op when task tag does not exist', () async {
       // Arrange
       const taskTagId = 'task-tag-1';
       final command = RemoveTaskTagCommand(id: taskTagId);
 
       when(mockTaskTagRepository.getById(taskTagId, includeDeleted: false)).thenAnswer((_) async => null);
 
-      // Act & Assert
-      expect(
-        () => handler(command),
-        throwsA(
-          predicate((e) => e is BusinessException && e.message == 'Task tag not found'),
-        ),
-      );
+      // Act
+      final result = await handler(command);
+
+      // Assert
+      expect(result.id, taskTagId);
       verify(mockTaskTagRepository.getById(taskTagId, includeDeleted: false)).called(1);
       verifyNever(mockTaskTagRepository.delete(any));
     });
 
-    // Test handling of already deleted task tag
-    test('should throw BusinessException when task tag is already deleted', () async {
+    // Test handling of already deleted task tag: same idempotent no-op behavior.
+    test('should return successfully as a no-op when task tag is already deleted', () async {
       // Arrange
       const taskTagId = 'task-tag-1';
       final existingTaskTag = TaskTag(
@@ -81,13 +81,11 @@ void main() {
 
       when(mockTaskTagRepository.getById(taskTagId, includeDeleted: false)).thenAnswer((_) async => existingTaskTag);
 
-      // Act & Assert
-      expect(
-        () => handler(command),
-        throwsA(
-          predicate((e) => e is BusinessException && e.message == 'Task tag already deleted'),
-        ),
-      );
+      // Act
+      final result = await handler(command);
+
+      // Assert
+      expect(result.id, taskTagId);
       verify(mockTaskTagRepository.getById(taskTagId, includeDeleted: false)).called(1);
       verifyNever(mockTaskTagRepository.delete(any));
     });
@@ -194,20 +192,18 @@ void main() {
     });
 
     // Test with empty string ID (edge case)
-    test('should handle empty string ID correctly', () async {
+    test('should handle empty string ID correctly as a no-op', () async {
       // Arrange
       const taskTagId = '';
       final command = RemoveTaskTagCommand(id: taskTagId);
 
       when(mockTaskTagRepository.getById(taskTagId, includeDeleted: false)).thenAnswer((_) async => null);
 
-      // Act & Assert
-      expect(
-        () => handler(command),
-        throwsA(
-          predicate((e) => e is BusinessException && e.message == 'Task tag not found'),
-        ),
-      );
+      // Act
+      final result = await handler(command);
+
+      // Assert
+      expect(result.id, taskTagId);
       verify(mockTaskTagRepository.getById(taskTagId, includeDeleted: false)).called(1);
       verifyNever(mockTaskTagRepository.delete(any));
     });


### PR DESCRIPTION
## Summary

Removing a tag from a task succeeded, but an unrelated "task tag not found" error overlay also appeared, per the report:

> Bir tasktan etiket kaldırılırken başarılı bir şekilde kaldırıyor fakat aynı zamanda bulunamadı hatası overlay notification olarak görüyorum.

**Root cause:** `TaskDetailsController.processTagChanges` diffs the cached `_taskTags` snapshot to compute which tags to remove, then sequentially awaits `removeTag()` per tag; the cache is only refreshed after a successful removal via `loadTaskTags()`. Nothing prevented `processTagChanges`/`onTagsSelected` from being re-invoked while a previous removal was still in flight, so a second call could diff against the stale snapshot and re-send `RemoveTaskTagCommand` for an association the first call had already soft-deleted. `RemoveTaskTagCommandHandler` then threw `BusinessException('Task tag not found', ...)` for the duplicate, which `AsyncErrorHandler`/`ErrorHelper` surfaced as an overlay — alongside the first call's successful removal.

## Fix

- `RemoveTaskTagCommandHandler`: treat "association not found" and "already deleted" as an idempotent successful no-op instead of throwing. The caller's desired end state (tag not on task) is already achieved, so this isn't a real error.
- `TaskDetailsController`: guard `processTagChanges` against concurrent/re-entrant calls, and remove tags from the local `_taskTags` cache optimistically before awaiting the remove command, so a racing diff can't re-target an association already being removed.
- Updated `remove_task_tag_command_test.dart` to assert the new no-op behavior for "not found" / "already deleted" / empty-id cases.

## Scope note

The same "throw not-found on duplicate remove" pattern exists in `RemoveHabitTagCommand`, `RemoveTagTagCommand`, `RemoveNoteTagCommand`, and `RemoveAppUsageTagCommand`. Only the reported task-tag path is fixed here to keep the change minimal; worth a follow-up if the same overlay is seen elsewhere.

## Test plan

- [x] `fvm flutter test test/core/application/features/tasks/commands/remove_task_tag_command_test.dart` — 8/8 pass
- [x] Confirmed no test regressions introduced by this diff (pre-existing unrelated failures in `import_tasks_command_test.dart` / `task_group_creation` / `save_task_command` default-estimated-time tests exist on this checkout independent of this change)
- [ ] Manual: open a task, add 2+ tags, remove one tag then immediately remove another before the first completes — confirm no "not found" overlay and both removals persist