### PR TITLE
fix(ui): disable inline tag display in list options to prevent button hiding

### DIFF
--- a/src/lib/presentation/ui/features/app_usages/components/app_usage_list_options.dart
+++ b/src/lib/presentation/ui/features/app_usages/components/app_usage_list_options.dart
@@ -394,6 +394,7 @@ class _AppUsageFiltersState extends PersistentListOptionsBaseState<AppUsageListO
                 [],
             onTagsSelected: _handleTagSelect,
             showLength: true,
+            showSelectedInDropdown: false,
             showNoneOption: true,
             initialNoneSelected: _currentState.showNoTagsFilter,
             icon: TagUiConstants.tagIcon,

--- a/src/lib/presentation/ui/features/calendar/components/today_page_list_options.dart
+++ b/src/lib/presentation/ui/features/calendar/components/today_page_list_options.dart
@@ -174,6 +174,7 @@ class _TodayPageListOptionsState extends PersistentListOptionsBaseState<TodayPag
                       ? Theme.of(context).primaryColor
                       : Colors.grey,
                   tooltip: _translationService.translate(TagTranslationKeys.selectTooltip),
+                  showSelectedInDropdown: false,
                   onTagsSelected: (selectedTags, isNoneSelected) {
                     final newTags = selectedTags.map((t) => t.value).toList();
                     widget.onFilterChange?.call(newTags, isNoneSelected);

--- a/src/lib/presentation/ui/features/habits/components/habit_list_options.dart
+++ b/src/lib/presentation/ui/features/habits/components/habit_list_options.dart
@@ -397,6 +397,7 @@ class _HabitListOptionsState extends PersistentListOptionsBaseState<HabitListOpt
                         : Colors.grey,
                     tooltip: _translationService.translate(HabitTranslationKeys.filterByTagsTooltip),
                     showLength: true,
+                    showSelectedInDropdown: false,
                     showNoneOption: true,
                     initialSelectedTags: widget.selectedTagIds != null
                         ? widget.selectedTagIds!.map((id) => DropdownOption<String>(value: id, label: id)).toList()

--- a/src/lib/presentation/ui/features/notes/components/note_list_options.dart
+++ b/src/lib/presentation/ui/features/notes/components/note_list_options.dart
@@ -283,6 +283,7 @@ class _NoteListOptionsState extends PersistentListOptionsBaseState<NoteListOptio
                         : Colors.grey,
                     tooltip: _translationService.translate(NoteTranslationKeys.filterTagsTooltip),
                     showLength: true,
+                    showSelectedInDropdown: false,
                     showNoneOption: true,
                     initialSelectedTags: widget.selectedTagIds != null
                         ? widget.selectedTagIds!.map((id) => DropdownOption<String>(value: id, label: id)).toList()

--- a/src/lib/presentation/ui/features/tags/components/tag_list_options.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_list_options.dart
@@ -298,6 +298,7 @@ class _TagListOptionsState extends PersistentListOptionsBaseState<TagListOptions
                     color: widget.selectedTagIds?.isNotEmpty ?? false ? primaryColor : Colors.grey,
                     tooltip: _translationService.translate(TagTranslationKeys.filterTagsTooltip),
                     showLength: true,
+                    showSelectedInDropdown: false,
                   ),
 
                 // Search filter

--- a/src/lib/presentation/ui/features/tags/components/tag_select_dropdown.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_select_dropdown.dart
@@ -307,8 +307,8 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
           .toList();
 
       if (widget.showSelectedInDropdown) {
-        displayWidget = SizedBox(
-            height: 48,
+        displayWidget = ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 200, maxHeight: 48),
             child: ReorderableListView.builder(
               scrollDirection: Axis.horizontal,
               buildDefaultDragHandles: false,

--- a/src/lib/presentation/ui/features/tasks/components/task_list_options.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_list_options.dart
@@ -545,6 +545,7 @@ class _TaskListOptionsState extends PersistentListOptionsBaseState<TaskListOptio
                         : Colors.grey,
                     tooltip: _translationService.translate(TaskTranslationKeys.filterByTagsTooltip),
                     showLength: true,
+                    showSelectedInDropdown: false,
                     showNoneOption: true,
                     initialSelectedTags: widget.selectedTagIds != null
                         ? widget.selectedTagIds!.map((id) => DropdownOption<String>(value: id, label: id)).toList()


### PR DESCRIPTION
### 🚀 Motivation and Context

List option barlarında (tasks, habits, notes, tags, calendar, app_usages) tag seçildiğinde tüm diğer butonlar (sort, group, save, search vb.) görünmez oluyor. Aynı sorun daha önce `QuickActionButtonsBar` için commit `ade0cab7`'de `showSelectedInDropdown: false` ile düzeltilmişti ancak list options bileşenlerine uygulanmamıştı.

### ⚙️ Implementation Details

**Root Cause:** `TagSelectDropdown.build()` varsayılan olarak `showSelectedInDropdown: true` kullanıyor. Tag seçildiğinde `ReorderableListView.builder(scrollDirection: horizontal)` oluşturuyor ve bunu `Flexible` ile sarıyor. Parent layout `SingleChildScrollView(horizontal)` içinde olduğu için genişlik sınırsız oluyor → `ReorderableListView` sonsuz genişlik alıyor → sibling butonlar ekran dışına itiliyor.

**Fix:** 6 list options bileşeninin tamamına `showSelectedInDropdown: false` eklendi. Bu sayede tag seçildiğinde sadece ikon rengi değişiyor (gri → primary), label/chip olarak gösterilmiyor, ve tüm butonlar görünür kalıyor. Quick add dialog'daki mevcut fix ile tutarlı bir yaklaşım.

### 📋 Checklist for Reviewer

- [ ] Tests passed locally (analiz temiz, mevcut test hataları drift migration kaynaklı ve bağımsız)
- [ ] Commit history is clean and descriptive
- [ ] Code quality standards met

### 🔗 Related

Closes related to the same root cause as `ade0cab7` (quick_action_buttons_bar fix)