### PR TITLE
fix(tasks): use priority colors for completion checkbox borders

### DIFF
--- a/src/lib/presentation/ui/features/tasks/components/status_aware_complete_button.dart
+++ b/src/lib/presentation/ui/features/tasks/components/status_aware_complete_button.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:whph/core/domain/features/tasks/task.dart';
 import 'package:whph/core/domain/features/tasks/task_status_constants.dart';
 import 'package:whph/presentation/ui/features/tasks/components/task_complete_button.dart';
+import 'package:whph/presentation/ui/features/tasks/constants/task_ui_constants.dart';
 import 'package:whph/presentation/ui/features/tasks/utils/status_loader_mixin.dart';
 import 'package:whph/presentation/ui/features/tasks/utils/task_status_display.dart';
 
@@ -10,6 +12,7 @@ class StatusAwareCompleteButton extends StatefulWidget {
   final String taskId;
   final bool isCompleted;
   final String? statusId;
+  final EisenhowerPriority? priority;
   final VoidCallback? onToggleCompleted;
   final double subTasksCompletionPercentage;
   final double size;
@@ -19,6 +22,7 @@ class StatusAwareCompleteButton extends StatefulWidget {
     required this.taskId,
     required this.isCompleted,
     this.statusId,
+    this.priority,
     this.onToggleCompleted,
     this.subTasksCompletionPercentage = 0.0,
     this.size = 24,
@@ -60,6 +64,7 @@ class _StatusAwareCompleteButtonState extends State<StatusAwareCompleteButton>
       isCompleted: widget.isCompleted,
       onToggleCompleted: widget.onToggleCompleted,
       color: _resolveStatusColor(),
+      borderColor: widget.priority == null ? null : TaskUiConstants.getPriorityColor(widget.priority),
       subTasksCompletionPercentage: widget.subTasksCompletionPercentage,
       size: widget.size,
     );

--- a/src/lib/presentation/ui/features/tasks/components/task_card.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_card.dart
@@ -157,6 +157,7 @@ class TaskCard extends StatelessWidget {
             taskId: taskItem.id,
             isCompleted: taskItem.isCompleted,
             statusId: taskItem.statusId,
+            priority: taskItem.priority,
             onToggleCompleted: null,
             subTasksCompletionPercentage: taskItem.subTasksCompletionPercentage,
             size: isDense ? AppTheme.iconSizeSmall : AppTheme.iconSizeMedium,

--- a/src/lib/presentation/ui/features/tasks/components/task_complete_button.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_complete_button.dart
@@ -17,6 +17,7 @@ class TaskCompleteButton extends StatefulWidget {
   final bool isCompleted;
   final VoidCallback? onToggleCompleted;
   final Color? color;
+  final Color? borderColor;
   final double subTasksCompletionPercentage;
   final double size;
 
@@ -26,6 +27,7 @@ class TaskCompleteButton extends StatefulWidget {
     required this.isCompleted,
     this.onToggleCompleted,
     this.color,
+    this.borderColor,
     this.subTasksCompletionPercentage = 0.0,
     this.size = AppTheme.buttonSize2XSmall,
   });
@@ -151,7 +153,7 @@ class _TaskCompleteButtonState extends State<TaskCompleteButton> {
   @override
   Widget build(BuildContext context) {
     final primaryColor = widget.color ?? Theme.of(context).colorScheme.primary;
-    final borderColor = widget.color ?? AppTheme.borderColor;
+    final borderColor = widget.borderColor ?? widget.color ?? AppTheme.borderColor;
     const double hoverSize = AppTheme.buttonSizeMedium;
 
     return SizedBox(

--- a/src/lib/presentation/ui/features/tasks/components/task_details_content/task_details_content.dart
+++ b/src/lib/presentation/ui/features/tasks/components/task_details_content/task_details_content.dart
@@ -536,6 +536,7 @@ class TaskDetailsContentState extends State<TaskDetailsContent> {
                 taskId: widget.taskId,
                 isCompleted: task.isCompleted,
                 statusId: task.statusId,
+                priority: task.priority,
                 onToggleCompleted: _controller.toggleTaskCompletion,
                 subTasksCompletionPercentage: task.subTasksCompletionPercentage,
               ),

--- a/src/test/presentation/ui/features/tasks/components/task_card_test.dart
+++ b/src/test/presentation/ui/features/tasks/components/task_card_test.dart
@@ -6,6 +6,7 @@ import 'package:whph/core/domain/features/tasks/task.dart';
 import 'package:whph/core/domain/features/tasks/task_status_constants.dart';
 import 'package:whph/core/domain/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/features/tasks/components/task_card.dart';
+import 'package:whph/presentation/ui/features/tasks/constants/task_ui_constants.dart';
 import 'package:whph/main.dart' as app_main;
 import 'package:mediatr/mediatr.dart';
 import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
@@ -13,7 +14,7 @@ import 'package:whph/presentation/ui/shared/services/abstraction/i_sound_manager
 import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
 import 'package:whph/presentation/ui/features/tasks/services/tasks_service.dart';
 import 'package:whph/core/application/features/tasks/services/abstraction/i_task_recurrence_service.dart';
-import 'package:acore/acore.dart';
+import 'package:acore/acore.dart' hide Container;
 import 'package:whph/core/application/features/tasks/queries/get_list_task_statuses_query.dart';
 
 class MockMediator extends Mock implements Mediator {

--- a/src/test/presentation/ui/features/tasks/components/task_card_test.dart
+++ b/src/test/presentation/ui/features/tasks/components/task_card_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:whph/core/application/features/tasks/models/task_list_item.dart';
 import 'package:whph/core/domain/features/tasks/task.dart';
+import 'package:whph/core/domain/features/tasks/task_status_constants.dart';
 import 'package:whph/core/domain/shared/constants/app_theme.dart';
 import 'package:whph/presentation/ui/features/tasks/components/task_card.dart';
 import 'package:whph/main.dart' as app_main;
@@ -571,6 +572,44 @@ void main() {
 
       // Act & Assert - Subtasks are rendered as flat list items, not inside the card
       expect(find.text('Subtask 1'), findsNothing);
+    });
+
+    testWidgets('incomplete task checkbox border uses priority color', (tester) async {
+      final priorityTask = TaskListItem(
+        id: 'priority-task-id',
+        title: 'Priority Task',
+        isCompleted: false,
+        priority: EisenhowerPriority.urgentImportant,
+        statusId: TaskStatusConstants.todoId,
+        tags: [],
+        subTasks: [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TaskCard(
+              taskItem: priorityTask,
+              onOpenDetails: () {},
+              onCompleted: (id) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final checkbox = tester.widget<Container>(find.byWidgetPredicate(
+        (widget) =>
+            widget is Container &&
+            widget.decoration is BoxDecoration &&
+            (widget.decoration! as BoxDecoration).shape == BoxShape.circle,
+      ));
+      final decoration = checkbox.decoration! as BoxDecoration;
+
+      expect(
+        (decoration.border! as Border).top.color,
+        TaskUiConstants.getPriorityColor(EisenhowerPriority.urgentImportant),
+      );
     });
   });
 }


### PR DESCRIPTION
### Context

Task completion checkbox borders now reflect the task priority whenever one is present.

---

### Implementation Details

- Add a separate optional border-color input to the completion control, keeping status-derived fill color behavior unchanged.
- Map task priority through `StatusAwareCompleteButton` for both task cards and task details.
- Add widget coverage proving priority takes precedence over a status color for the checkbox border.

> [!IMPORTANT]
> The focused regression test passed locally with `nix develop --command fvm flutter test test/presentation/ui/features/tasks/components/task_card_test.dart --plain-name "incomplete task checkbox border uses priority color"`.

---

### Checklist for Reviewer

- [x] Focused regression test passed locally.
- [x] Commit history is clean and descriptive.
- [ ] Documentation updated (not applicable).
- [x] LSP diagnostics are clean for modified files.