### PR TITLE
fix(tags): show all selected tags in details

### DIFF
--- a/src/lib/presentation/ui/features/tags/components/tag_select_dropdown.dart
+++ b/src/lib/presentation/ui/features/tags/components/tag_select_dropdown.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:whph/core/domain/shared/utils/logger.dart';
 import 'package:collection/collection.dart';
 import 'package:mediatr/mediatr.dart';
 import 'package:whph/core/application/features/tags/queries/get_list_tags_query.dart';
@@ -18,6 +17,7 @@ import 'package:acore/utils/responsive_dialog_helper.dart';
 import 'package:whph/presentation/ui/features/tags/pages/tag_details_page.dart';
 import 'package:whph/presentation/ui/features/tags/components/tag_options_dialog.dart';
 import 'package:acore/acore.dart' show SortDirection, SortOption;
+import 'package:whph/core/domain/features/tags/tag.dart';
 
 class TagSelectDropdown extends StatefulWidget {
   final List<DropdownOption<String>> initialSelectedTags;
@@ -37,7 +37,8 @@ class TagSelectDropdown extends StatefulWidget {
   final bool initialShowNoTagsFilter;
   final bool autoOpen; // NEW: Auto-open overlay on first build
 
-  final Function(List<DropdownOption<String>>, bool isNoneSelected) onTagsSelected;
+  final Function(List<DropdownOption<String>>, bool isNoneSelected)
+      onTagsSelected;
   final Widget? headerAction;
   final ButtonStyle? buttonStyle;
 
@@ -82,7 +83,8 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
   void initState() {
     _selectedTags = widget.initialSelectedTags.map((e) => e.value).toList();
     _hasExplicitlySelectedNone = widget.showNoneOption &&
-        (_selectedTags.isEmpty && (widget.initialShowNoTagsFilter || widget.initialNoneSelected));
+        (_selectedTags.isEmpty &&
+            (widget.initialShowNoTagsFilter || widget.initialNoneSelected));
 
     if (_hasExplicitlySelectedNone) {
       _selectedTags.clear();
@@ -106,7 +108,8 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
   void didUpdateWidget(TagSelectDropdown oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (_selectedTagsChanged(oldWidget.initialSelectedTags, widget.initialSelectedTags)) {
+    if (_selectedTagsChanged(
+        oldWidget.initialSelectedTags, widget.initialSelectedTags)) {
       _selectedTags = widget.initialSelectedTags.map((e) => e.value).toList();
       _needsStateUpdate = true;
     }
@@ -119,7 +122,8 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
     if (oldWidget.initialShowNoTagsFilter != widget.initialShowNoTagsFilter ||
         oldWidget.initialNoneSelected != widget.initialNoneSelected) {
       _hasExplicitlySelectedNone = widget.showNoneOption &&
-          (_selectedTags.isEmpty && (widget.initialShowNoTagsFilter || widget.initialNoneSelected));
+          (_selectedTags.isEmpty &&
+              (widget.initialShowNoTagsFilter || widget.initialNoneSelected));
 
       if (_hasExplicitlySelectedNone) {
         _selectedTags.clear();
@@ -144,7 +148,9 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
     }
 
     // NEW: Auto-open if autoOpen changes to true
-    if (widget.autoOpen != oldWidget.autoOpen && widget.autoOpen && !_hasAutoOpened) {
+    if (widget.autoOpen != oldWidget.autoOpen &&
+        widget.autoOpen &&
+        !_hasAutoOpened) {
       _hasAutoOpened = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
@@ -154,7 +160,8 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
     }
   }
 
-  bool _selectedTagsChanged(List<DropdownOption<String>> oldTags, List<DropdownOption<String>> newTags) {
+  bool _selectedTagsChanged(List<DropdownOption<String>> oldTags,
+      List<DropdownOption<String>> newTags) {
     if (oldTags.length != newTags.length) {
       return true;
     }
@@ -168,10 +175,16 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
     return false;
   }
 
+  String? _getInitialSelectedTagLabel(String tagId) =>
+      widget.initialSelectedTags
+          .firstWhereOrNull((tag) => tag.value == tagId)
+          ?.label;
+
   Future<void> _getTags({required int pageIndex, String? search}) async {
     await AsyncErrorHandler.execute<GetListTagsQueryResponse>(
       context: context,
-      errorMessage: _translationService.translate(TagTranslationKeys.errorLoading),
+      errorMessage:
+          _translationService.translate(TagTranslationKeys.errorLoading),
       operation: () async {
         final query = GetListTagsQuery(
           pageIndex: pageIndex,
@@ -185,20 +198,24 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
             ),
           ],
         );
-        return await _mediator.send<GetListTagsQuery, GetListTagsQueryResponse>(query);
+        return await _mediator
+            .send<GetListTagsQuery, GetListTagsQueryResponse>(query);
       },
       onSuccess: (result) {
         if (mounted) {
           setState(() {
             if (widget.excludeTagIds.isNotEmpty) {
-              result.items.removeWhere((tag) => widget.excludeTagIds.contains(tag.id));
+              result.items
+                  .removeWhere((tag) => widget.excludeTagIds.contains(tag.id));
             }
 
             if (_tags == null) {
               _tags = result;
             } else {
               final existingIds = _tags!.items.map((t) => t.id).toSet();
-              final newItems = result.items.where((t) => !existingIds.contains(t.id)).toList();
+              final newItems = result.items
+                  .where((t) => !existingIds.contains(t.id))
+                  .toList();
               _tags!.items.addAll(newItems);
               _tags!.pageIndex = result.pageIndex;
             }
@@ -220,18 +237,10 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
     // Construct the updated list of DropdownOptions to pass back
     final List<DropdownOption<String>> updatedTags = _selectedTags.map((tagId) {
       // Find tag name
-      String label = '';
-      if (_tags != null) {
-        try {
-          final tag = _tags!.items.firstWhere((t) => t.id == tagId);
-          label = tag.name;
-        } catch (e, stackTrace) {
-          const errorCode = 'tag_select_tag_not_found';
-          Logger.warning('$errorCode: Tag not found for id: $tagId',
-              component: 'TagSelectDropdown', error: e, stackTrace: stackTrace);
-          label = _translationService.translate(SharedTranslationKeys.untitled);
-        }
-      }
+      final tag = _tags?.items.firstWhereOrNull((item) => item.id == tagId);
+      final label = tag?.name ??
+          _getInitialSelectedTagLabel(tagId) ??
+          _translationService.translate(SharedTranslationKeys.untitled);
       return DropdownOption(label: label, value: tagId);
     }).toList();
 
@@ -256,7 +265,8 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
     );
 
     if (result != null && result is Map && mounted) {
-      final selectedOptions = result['selectedTags'] as List<DropdownOption<String>>;
+      final selectedOptions =
+          result['selectedTags'] as List<DropdownOption<String>>;
       final isNoneSelected = result['isNoneSelected'] as bool;
 
       setState(() {
@@ -288,23 +298,21 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
           color: widget.color ?? Theme.of(context).iconTheme.color,
         ),
       );
-      displayTooltip = _translationService.translate(SharedTranslationKeys.noneOption);
+      displayTooltip =
+          _translationService.translate(SharedTranslationKeys.noneOption);
     } else if (_selectedTags.isNotEmpty && _tags != null) {
       final uniqueSelectedTagIds = _selectedTags.toSet().toList();
-      final selectedTagNames = uniqueSelectedTagIds
-          .map((id) {
-            try {
-              final tag = _tags!.items.firstWhere((t) => t.id == id);
-              return tag.name.isNotEmpty ? tag.name : _translationService.translate(SharedTranslationKeys.untitled);
-            } catch (e, stackTrace) {
-              const errorCode = 'tag_select_tag_not_found';
-              Logger.warning('$errorCode: Tag not found for id: $id',
-                  component: 'TagSelectDropdown', error: e, stackTrace: stackTrace);
-              return null;
-            }
-          })
-          .whereType<String>()
-          .toList();
+      final selectedTagNames = uniqueSelectedTagIds.map((id) {
+        final tag = _tags!.items.firstWhereOrNull((t) => t.id == id);
+        if (tag != null) {
+          return tag.name.isNotEmpty
+              ? tag.name
+              : _translationService.translate(SharedTranslationKeys.untitled);
+        }
+        final fallbackLabel = _getInitialSelectedTagLabel(id);
+        return fallbackLabel ??
+            _translationService.translate(SharedTranslationKeys.untitled);
+      }).toList();
 
       if (widget.showSelectedInDropdown) {
         displayWidget = ReorderableListView.builder(
@@ -330,15 +338,24 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
             }
 
             final tag = tagsResponse.items.firstWhereOrNull((t) => t.id == id);
-            if (tag == null) {
+            final fallbackLabel = _getInitialSelectedTagLabel(id);
+            if (tag == null && fallbackLabel == null) {
               return SizedBox.shrink(key: ValueKey('empty_no_tag_$id'));
             }
+
+            final displayName = tag?.name ??
+                fallbackLabel ??
+                _translationService.translate(SharedTranslationKeys.untitled);
+            final tagType = tag?.type ?? TagType.label;
+            final tagColor = tag?.color;
 
             return ReorderableDelayedDragStartListener(
               key: ValueKey('drag_listener_$id'),
               index: index,
               child: GestureDetector(
                 onTap: () async {
+                  if (tag == null) return;
+
                   final result = await TagOptionsDialog.show(
                     context: context,
                     tag: tag,
@@ -351,12 +368,21 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
                     if (currentTags == null) return;
 
                     final List<DropdownOption<String>> updatedTags =
-                        uniqueSelectedTagIds.where((tagId) => tagId != id).map((tagId) {
-                      final tagItem = currentTags.items.firstWhereOrNull((t) => t.id == tagId);
-                      return DropdownOption(label: tagItem?.name ?? '', value: tagId);
+                        uniqueSelectedTagIds
+                            .where((tagId) => tagId != id)
+                            .map((tagId) {
+                      final tagItem = currentTags.items
+                          .firstWhereOrNull((item) => item.id == tagId);
+                      return DropdownOption(
+                        label: tagItem?.name ??
+                            _getInitialSelectedTagLabel(tagId) ??
+                            '',
+                        value: tagId,
+                      );
                     }).toList();
 
-                    widget.onTagsSelected(updatedTags, _hasExplicitlySelectedNone);
+                    widget.onTagsSelected(
+                        updatedTags, _hasExplicitlySelectedNone);
                     setState(() {
                       _selectedTags.removeWhere((tagId) => tagId == id);
                     });
@@ -374,15 +400,16 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Icon(
-                        TagUiConstants.getTagTypeIcon(tag.type),
+                        TagUiConstants.getTagTypeIcon(tagType),
                         size: AppTheme.iconSizeXSmall,
-                        color: TagUiConstants.getTagColor(tag.color),
+                        color: TagUiConstants.getTagColor(tagColor),
                       ),
                       const SizedBox(width: 4),
                       Text(
-                          tag.name.isNotEmpty
-                              ? tag.name
-                              : _translationService.translate(SharedTranslationKeys.untitled),
+                          displayName.isNotEmpty
+                              ? displayName
+                              : _translationService
+                                  .translate(SharedTranslationKeys.untitled),
                           style: AppTheme.labelSmall),
                     ],
                   ),
@@ -440,7 +467,9 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (widget.showSelectedInDropdown && _selectedTags.isNotEmpty && _tags != null)
+        if (widget.showSelectedInDropdown &&
+            _selectedTags.isNotEmpty &&
+            _tags != null)
           Flexible(
             child: displayWidget,
           )
@@ -468,7 +497,9 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
                   tooltip: displayTooltip ?? '',
                   style: widget.buttonStyle,
                 ),
-        if (widget.showSelectedInDropdown && _selectedTags.isNotEmpty && _tags != null)
+        if (widget.showSelectedInDropdown &&
+            _selectedTags.isNotEmpty &&
+            _tags != null)
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 4.0),
             child: IconButton(
@@ -480,7 +511,8 @@ class _TagSelectDropdownState extends State<TagSelectDropdown> {
               ),
               iconSize: widget.iconSize ?? AppTheme.iconSizeMedium,
               onPressed: () => _showTagSelectionModal(context),
-              tooltip: _translationService.translate(TagTranslationKeys.selectTooltip),
+              tooltip: _translationService
+                  .translate(TagTranslationKeys.selectTooltip),
               style: widget.buttonStyle,
             ),
           ),

--- a/src/test/presentation/ui/features/tags/components/tag_select_dropdown_test.dart
+++ b/src/test/presentation/ui/features/tags/components/tag_select_dropdown_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mediatr/mediatr.dart';
+import 'package:acore/acore.dart';
+import 'package:whph/core/application/features/tags/queries/get_list_tags_query.dart';
+import 'package:whph/core/domain/features/tags/tag.dart';
+import 'package:whph/main.dart';
+import 'package:whph/presentation/ui/features/tags/components/tag_select_dropdown.dart';
+import 'package:whph/presentation/ui/shared/models/dropdown_option.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
+
+class _FakeContainer extends Fake implements IContainer {
+  final Map<Type, dynamic> _services = {};
+
+  void register<T>(T service) {
+    _services[T] = service;
+  }
+
+  @override
+  T resolve<T>() {
+    final service = _services[T];
+    if (service == null) {
+      throw Exception('Service of type $T not registered in mock container');
+    }
+    return service as T;
+  }
+}
+
+class _FakeMediator extends Fake implements Mediator {
+  final GetListTagsQueryResponse response;
+
+  _FakeMediator(this.response);
+
+  @override
+  Future<TResponse> send<TRequest extends IRequest<TResponse>, TResponse>(
+          TRequest request) async =>
+      response as TResponse;
+}
+
+class _FakeTranslationService extends Fake implements ITranslationService {
+  @override
+  String translate(String key, {Map<String, String>? namedArgs}) => key;
+}
+
+void main() {
+  group('TagSelectDropdown', () {
+    testWidgets(
+        'should render all selected tags in horizontal ReorderableListView '
+        'even when GetListTagsQuery returns only first page',
+        (WidgetTester tester) async {
+      final selectedTagIds = ['tag-1', 'tag-2', 'tag-3'];
+      final initialSelectedTags = selectedTagIds
+          .map((id) => DropdownOption(label: 'Tag $id', value: id))
+          .toList();
+
+      final response = GetListTagsQueryResponse(
+        items: [
+          TagListItem(
+            id: 'tag-1',
+            name: 'Tag tag-1',
+            type: TagType.label,
+          ),
+        ],
+        totalItemCount: 3,
+        pageIndex: 0,
+        pageSize: 10,
+      );
+
+      final fakeContainer = _FakeContainer();
+      fakeContainer.register<Mediator>(_FakeMediator(response));
+      fakeContainer.register<ITranslationService>(_FakeTranslationService());
+      container = fakeContainer;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TagSelectDropdown(
+              initialSelectedTags: initialSelectedTags,
+              onTagsSelected: (tags, isNoneSelected) {},
+              showSelectedInDropdown: true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(ReorderableListView),
+        findsOneWidget,
+        reason: 'Should render horizontal ReorderableListView',
+      );
+
+      expect(
+        find.byType(Chip),
+        findsNWidgets(3),
+        reason:
+            'Should render 3 chips for all selected tags, but only renders 1 due to pagination bug',
+      );
+
+      final reorderableListView = find.byType(ReorderableListView);
+      expect(reorderableListView, findsOneWidget);
+
+      final widget = tester.widget<ReorderableListView>(reorderableListView);
+      expect(
+        widget.scrollDirection,
+        Axis.horizontal,
+        reason: 'ReorderableListView should scroll horizontally',
+      );
+    });
+  });
+}


### PR DESCRIPTION
### 🚀 Context

Fixes tag detail views where selected related tags were omitted from the horizontal selector when they were not included in the first paginated tag response.

---

### ⚙️ Implementation Details

- Use `initialSelectedTags` labels as a fallback when selected tag metadata is absent from the loaded page.
- Preserve the existing horizontal reorderable chip list and tag metadata behavior when data is loaded.
- Add a widget regression test covering three selected tags with only one returned by the query.

---

### 📋 Checklist for Reviewer

- [x] Focused widget test passed locally.
- [x] Commit history is clean and descriptive.
- [x] Documentation updated (not applicable).
- [x] Targeted diagnostics are clean.