### PR TITLE
feat(tasks): let the quick add task dialog be minimized

### DIFF
--- a/scripts/start_android_emulator.sh
+++ b/scripts/start_android_emulator.sh
@@ -71,7 +71,12 @@ echo "Booting AVD '$avd_name'..."
 # group, and a merely nohup'd child stays in that group - the emulator would die
 # moments after this script reported success, leaving the debug session to fail
 # with "device 'emulator-5554' not found". A new session detaches it for good.
-setsid "$EMULATOR" -avd "$avd_name" -netdelay none -netspeed full \
+# `-gpu swangle` overrides whatever the AVD stores. Android Studio writes the
+# mode `swiftshader_indirect`, which emulator 37 no longer accepts; it falls back
+# to `auto`, picks the host GPU, and on a Wayland session without working host
+# GL it renders nothing - the window opens but stays black and the device never
+# reports sys.boot_completed. swangle is the supported software renderer.
+setsid "$EMULATOR" -avd "$avd_name" -gpu swangle -netdelay none -netspeed full \
   >/tmp/whph_emulator.log 2>&1 < /dev/null &
 disown 2>/dev/null || true
 

--- a/src/lib/presentation/ui/features/tasks/assets/locales/cs.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/cs.yaml
@@ -440,6 +440,8 @@ tasks:
       planned_date_not_set: "Plánováno: Není nastaveno"
       lock: Uzamknout
       unlock: Odemknout
+      minimize: Minimalizovat
+      restore: Obnovit
     new_task_default_title: Nový úkol
   recurrence:
     count: Počet výskytů

--- a/src/lib/presentation/ui/features/tasks/assets/locales/da.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/da.yaml
@@ -442,6 +442,8 @@ tasks:
       planned_date_not_set: "Planlagt: Ikke sat"
       lock: Lås
       unlock: Lås op
+      minimize: Minimer
+      restore: Gendan
     new_task_default_title: Ny opgave
   recurrence:
     count: Antal forekomster

--- a/src/lib/presentation/ui/features/tasks/assets/locales/de.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/de.yaml
@@ -444,6 +444,8 @@ tasks:
       planned_date_not_set: "Geplant: Nicht festgelegt"
       lock: Sperren
       unlock: Entsperren
+      minimize: Minimieren
+      restore: Wiederherstellen
     new_task_default_title: Neue Aufgabe
   recurrence:
     count: Anzahl der Wiederholungen

--- a/src/lib/presentation/ui/features/tasks/assets/locales/el.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/el.yaml
@@ -370,6 +370,8 @@ tasks:
       planned_date_not_set: "Προγραμματισμένο: Δεν ορίστηκε"
       lock: Κλείδωμα
       unlock: Ξεκλείδωμα
+      minimize: Ελαχιστοποίηση
+      restore: Επαναφορά
     new_task_default_title: Νέα εργασία
   recurrence:
     count: Αριθμός επαναλήψεων

--- a/src/lib/presentation/ui/features/tasks/assets/locales/en.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/en.yaml
@@ -349,6 +349,8 @@ tasks:
       planned_date_not_set: "Planned: Not set"
       lock: Lock
       unlock: Unlock
+      minimize: Minimize
+      restore: Restore
   recurrence:
     count: Number of occurrences
     custom: Custom

--- a/src/lib/presentation/ui/features/tasks/assets/locales/es.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/es.yaml
@@ -443,6 +443,8 @@ tasks:
       planned_date_not_set: "Planificado: No establecido"
       lock: Bloquear
       unlock: Desbloquear
+      minimize: Minimizar
+      restore: Restaurar
     new_task_default_title: Nueva tarea
   recurrence:
     count: Número de ocurrencias

--- a/src/lib/presentation/ui/features/tasks/assets/locales/fi.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/fi.yaml
@@ -357,6 +357,8 @@ tasks:
       planned_date_not_set: "Suunniteltu: Ei asetettu"
       lock: Lukitse
       unlock: Avaa lukitus
+      minimize: Pienennä
+      restore: Palauta
     new_task_default_title: Uusi tehtävä
   recurrence:
     count: Toistojen Määrä

--- a/src/lib/presentation/ui/features/tasks/assets/locales/fr.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/fr.yaml
@@ -448,6 +448,8 @@ tasks:
       planned_date_not_set: "Prévu : Non défini"
       lock: Verrouiller
       unlock: Déverrouiller
+      minimize: Réduire
+      restore: Restaurer
     new_task_default_title: Nouvelle tâche
   recurrence:
     count: Nombre d'occurrences

--- a/src/lib/presentation/ui/features/tasks/assets/locales/it.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/it.yaml
@@ -444,6 +444,8 @@ tasks:
       planned_date_not_set: "Pianificato: Non impostato"
       lock: Blocca
       unlock: Sblocca
+      minimize: Riduci a icona
+      restore: Ripristina
     new_task_default_title: Nuova attività
   recurrence:
     count: Numero di occorrenze

--- a/src/lib/presentation/ui/features/tasks/assets/locales/ja.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/ja.yaml
@@ -401,6 +401,8 @@ tasks:
       planned_date_not_set: "予定: 未設定"
       lock: ロック
       unlock: ロック解除
+      minimize: 最小化
+      restore: 元に戻す
     new_task_default_title: 新しいタスク
   recurrence:
     count: 発生回数

--- a/src/lib/presentation/ui/features/tasks/assets/locales/ko.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/ko.yaml
@@ -407,6 +407,8 @@ tasks:
       planned_date_not_set: "계획일: 설정되지 않음"
       lock: 잠금
       unlock: 잠금 해제
+      minimize: 최소화
+      restore: 복원
     new_task_default_title: 새 작업
   recurrence:
     count: 발생 횟수

--- a/src/lib/presentation/ui/features/tasks/assets/locales/nl.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/nl.yaml
@@ -362,6 +362,8 @@ tasks:
       planned_date_not_set: "Gepland: Niet ingesteld"
       lock: Vergrendelen
       unlock: Ontgrendelen
+      minimize: Minimaliseren
+      restore: Herstellen
     new_task_default_title: Nieuwe taak
   recurrence:
     count: Aantal herhalingen

--- a/src/lib/presentation/ui/features/tasks/assets/locales/no.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/no.yaml
@@ -360,6 +360,8 @@ tasks:
       planned_date_not_set: "Planlagt: Ikke satt"
       lock: Lås
       unlock: Lås opp
+      minimize: Minimer
+      restore: Gjenopprett
     new_task_default_title: Ny oppgave
   recurrence:
     count: Antall forekomster

--- a/src/lib/presentation/ui/features/tasks/assets/locales/pl.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/pl.yaml
@@ -440,6 +440,8 @@ tasks:
       planned_date_not_set: "Planowane: Nie ustawiono"
       lock: Zablokuj
       unlock: Odblokuj
+      minimize: Minimalizuj
+      restore: Przywróć
     new_task_default_title: Nowe zadanie
   recurrence:
     count: Liczba wystąpień

--- a/src/lib/presentation/ui/features/tasks/assets/locales/pt.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/pt.yaml
@@ -363,6 +363,8 @@ tasks:
       planned_date_not_set: "Planejado: Não definido"
       lock: Bloquear
       unlock: Desbloquear
+      minimize: Minimizar
+      restore: Restaurar
     new_task_default_title: Nova tarefa
   recurrence:
     count: Número de ocorrências

--- a/src/lib/presentation/ui/features/tasks/assets/locales/ro.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/ro.yaml
@@ -366,6 +366,8 @@ tasks:
       planned_date_not_set: "Planificat: Nu setat"
       lock: Blocare
       unlock: Deblocare
+      minimize: Minimizare
+      restore: Restaurare
     new_task_default_title: Sarcină nouă
   recurrence:
     count: Număr de apariții

--- a/src/lib/presentation/ui/features/tasks/assets/locales/ru.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/ru.yaml
@@ -442,6 +442,8 @@ tasks:
       planned_date_not_set: "Запланировано: Не установлено"
       lock: Заблокировать
       unlock: Разблокировать
+      minimize: Свернуть
+      restore: Восстановить
     new_task_default_title: Новая задача
   recurrence:
     count: Количество повторений

--- a/src/lib/presentation/ui/features/tasks/assets/locales/sl.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/sl.yaml
@@ -358,6 +358,8 @@ tasks:
       planned_date_not_set: "Načrtovano: Ni nastavljen"
       lock: Zakleni
       unlock: Odkleni
+      minimize: Pomanjšaj
+      restore: Obnovi
     new_task_default_title: Novo opravilo
   recurrence:
     count: Število pojavitev

--- a/src/lib/presentation/ui/features/tasks/assets/locales/sv.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/sv.yaml
@@ -358,6 +358,8 @@ tasks:
       planned_date_not_set: "Planerad: Inte inställd"
       lock: Lås
       unlock: Lås upp
+      minimize: Minimera
+      restore: Återställ
     new_task_default_title: Ny uppgift
   recurrence:
     count: Antal förekomster

--- a/src/lib/presentation/ui/features/tasks/assets/locales/tr.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/tr.yaml
@@ -400,6 +400,8 @@ tasks:
       planned_date_not_set: "Planlanan: Ayarlanmadı"
       lock: Kilitle
       unlock: Kilidi Aç
+      minimize: Küçült
+      restore: Geri Yükle
   recurrence:
     count: Tekrarlama sayısı
     custom: Özel

--- a/src/lib/presentation/ui/features/tasks/assets/locales/uk.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/uk.yaml
@@ -441,6 +441,8 @@ tasks:
       planned_date_not_set: "Заплановано: Не встановлено"
       lock: Заблокувати
       unlock: Розблокувати
+      minimize: Згорнути
+      restore: Відновити
     new_task_default_title: Нове завдання
   recurrence:
     count: Кількість повторень

--- a/src/lib/presentation/ui/features/tasks/assets/locales/zh.yaml
+++ b/src/lib/presentation/ui/features/tasks/assets/locales/zh.yaml
@@ -398,6 +398,8 @@ tasks:
       planned_date_not_set: 计划日期：未设置
       lock: 锁定
       unlock: 解锁
+      minimize: 最小化
+      restore: 还原
     new_task_default_title: 新任务
   recurrence:
     count: 发生次数

--- a/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/components/quick_action_buttons_bar.dart
+++ b/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/components/quick_action_buttons_bar.dart
@@ -21,6 +21,10 @@ class QuickActionButtonsBar extends StatelessWidget {
   final Widget? tagLockAction;
   final bool isMobile;
 
+  /// Collapses the sheet so the content behind it becomes reachable.
+  /// Null when the host cannot collapse, which hides the affordance entirely.
+  final VoidCallback? onMinimize;
+
   const QuickActionButtonsBar({
     super.key,
     required this.controller,
@@ -33,6 +37,7 @@ class QuickActionButtonsBar extends StatelessWidget {
     required this.onClearAllFields,
     this.tagLockAction,
     required this.isMobile,
+    this.onMinimize,
   });
 
   @override
@@ -59,7 +64,20 @@ class QuickActionButtonsBar extends StatelessWidget {
         _buildDeadlineDateButton(theme, iconSize),
         SizedBox(width: buttonGap),
         _buildClearButton(theme, iconSize),
+        if (onMinimize != null) ...[
+          SizedBox(width: buttonGap),
+          _buildMinimizeButton(theme, iconSize),
+        ],
       ],
+    );
+  }
+
+  Widget _buildMinimizeButton(ThemeData theme, double iconSize) {
+    return QuickActionIconButton(
+      icon: Icons.close_fullscreen,
+      onPressed: onMinimize!,
+      tooltip: controller.translationService.translate(TaskTranslationKeys.quickTaskMinimize),
+      iconSize: iconSize,
     );
   }
 

--- a/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/minimizable_routes.dart
+++ b/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/minimizable_routes.dart
@@ -5,20 +5,14 @@ import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 ///
 /// The controller is owned by the code that pushes the route, so it outlives
 /// rebuilds of the route content and never resets while the route is alive.
-class SheetMinimizeController extends ChangeNotifier {
-  bool _isMinimized = false;
+typedef SheetMinimizeController = ValueNotifier<bool>;
 
-  bool get isMinimized => _isMinimized;
+extension SheetMinimizeControls on SheetMinimizeController {
+  bool get isMinimized => value;
 
-  void minimize() => _setMinimized(true);
+  void minimize() => value = true;
 
-  void restore() => _setMinimized(false);
-
-  void _setMinimized(bool value) {
-    if (_isMinimized == value) return;
-    _isMinimized = value;
-    notifyListeners();
-  }
+  void restore() => value = false;
 }
 
 /// Exposes a [SheetMinimizeController] to the route content.
@@ -70,20 +64,22 @@ class MinimizableSheetRoute<T> extends ModalSheetRoute<T> {
 
 /// Mirrors the private container builder used by [showMaterialModalBottomSheet]
 /// so a custom route keeps the stock material sheet appearance.
-WidgetWithChildBuilder buildMaterialSheetContainer(BuildContext context) {
-  final theme = Theme.of(context);
-  final sheetTheme = theme.bottomSheetTheme;
+///
+/// The theme is resolved from the builder context rather than captured when the
+/// route is pushed, so the sheet repaints with the app when the theme changes
+/// while it is open.
+WidgetWithChildBuilder buildMaterialSheetContainer() {
+  return (builderContext, animation, child) {
+    final sheetTheme = Theme.of(builderContext).bottomSheetTheme;
 
-  return (builderContext, animation, child) => Theme(
-        data: theme,
-        child: Material(
-          color: sheetTheme.modalBackgroundColor ?? sheetTheme.backgroundColor,
-          elevation: sheetTheme.elevation ?? 0.0,
-          shape: sheetTheme.shape,
-          clipBehavior: sheetTheme.clipBehavior ?? Clip.none,
-          child: child,
-        ),
-      );
+    return Material(
+      color: sheetTheme.modalBackgroundColor ?? sheetTheme.backgroundColor,
+      elevation: sheetTheme.elevation ?? 0.0,
+      shape: sheetTheme.shape,
+      clipBehavior: sheetTheme.clipBehavior ?? Clip.none,
+      child: child,
+    );
+  };
 }
 
 /// The desktop counterpart of [MinimizableSheetRoute].

--- a/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/minimizable_routes.dart
+++ b/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/minimizable_routes.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart' hide ModalBottomSheetRoute;
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+
+/// Tracks whether a minimizable modal route is currently collapsed.
+///
+/// The controller is owned by the code that pushes the route, so it outlives
+/// rebuilds of the route content and never resets while the route is alive.
+class SheetMinimizeController extends ChangeNotifier {
+  bool _isMinimized = false;
+
+  bool get isMinimized => _isMinimized;
+
+  void minimize() => _setMinimized(true);
+
+  void restore() => _setMinimized(false);
+
+  void _setMinimized(bool value) {
+    if (_isMinimized == value) return;
+    _isMinimized = value;
+    notifyListeners();
+  }
+}
+
+/// Exposes a [SheetMinimizeController] to the route content.
+///
+/// Absent when the host route cannot collapse, which lets descendants hide the
+/// minimize affordance instead of showing a dead one.
+class SheetMinimizeScope extends InheritedNotifier<SheetMinimizeController> {
+  const SheetMinimizeScope({
+    super.key,
+    required SheetMinimizeController controller,
+    required super.child,
+  }) : super(notifier: controller);
+
+  static SheetMinimizeController? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<SheetMinimizeScope>()?.notifier;
+  }
+}
+
+/// A material modal bottom sheet whose barrier disappears while minimized.
+///
+/// Dropping the barrier is what makes the content behind the sheet scrollable
+/// and tappable again. The route itself is never popped, so the sheet's [State]
+/// - and therefore every value the user already entered - stays alive.
+class MinimizableSheetRoute<T> extends ModalSheetRoute<T> {
+  MinimizableSheetRoute({
+    required this.minimizeController,
+    required super.builder,
+    super.containerBuilder,
+    super.barrierLabel,
+    super.isDismissible,
+    super.enableDrag,
+    super.settings,
+    super.expanded = false,
+  });
+
+  final SheetMinimizeController minimizeController;
+
+  @override
+  Widget buildModalBarrier() {
+    return AnimatedBuilder(
+      animation: minimizeController,
+      builder: (context, _) {
+        if (minimizeController.isMinimized) return const SizedBox.shrink();
+        return super.buildModalBarrier();
+      },
+    );
+  }
+}
+
+/// Mirrors the private container builder used by [showMaterialModalBottomSheet]
+/// so a custom route keeps the stock material sheet appearance.
+WidgetWithChildBuilder buildMaterialSheetContainer(BuildContext context) {
+  final theme = Theme.of(context);
+  final sheetTheme = theme.bottomSheetTheme;
+
+  return (builderContext, animation, child) => Theme(
+        data: theme,
+        child: Material(
+          color: sheetTheme.modalBackgroundColor ?? sheetTheme.backgroundColor,
+          elevation: sheetTheme.elevation ?? 0.0,
+          shape: sheetTheme.shape,
+          clipBehavior: sheetTheme.clipBehavior ?? Clip.none,
+          child: child,
+        ),
+      );
+}
+
+/// The desktop counterpart of [MinimizableSheetRoute].
+///
+/// [DialogRoute] is a [PopupRoute], so `opaque` is already `false` and the route
+/// below stays mounted and painted. The only thing intercepting pointers is the
+/// [ModalBarrier] built by [ModalRoute.buildModalBarrier], so dropping it while
+/// minimized hands input back to the page behind without popping this route.
+class MinimizableDialogRoute<T> extends DialogRoute<T> {
+  MinimizableDialogRoute({
+    required this.minimizeController,
+    required super.context,
+    required super.builder,
+    super.themes,
+    super.barrierColor,
+    super.barrierDismissible,
+    super.barrierLabel,
+    super.settings,
+  });
+
+  final SheetMinimizeController minimizeController;
+
+  @override
+  Widget buildModalBarrier() {
+    return AnimatedBuilder(
+      animation: minimizeController,
+      builder: (context, _) {
+        if (minimizeController.isMinimized) return const SizedBox.shrink();
+        return super.buildModalBarrier();
+      },
+    );
+  }
+}

--- a/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog.dart
+++ b/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
-import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:whph/core/domain/features/tasks/task.dart';
 import 'package:whph/core/domain/shared/utils/logger.dart';
 import 'package:acore/acore.dart' as acore;
@@ -18,9 +17,14 @@ import '../dialogs/priority_selection_dialog.dart';
 import 'dialogs/clear_fields_confirmation_dialog.dart';
 import 'controllers/quick_add_task_controller.dart';
 import 'components/quick_action_buttons_bar.dart';
+import 'minimizable_routes.dart';
 
 import '../task_date_picker_dialog.dart';
 import '../../pages/task_details_page.dart';
+
+/// Width of the collapsed desktop dialog, small enough to read as a floating
+/// bar instead of a dialog that merely lost its body.
+const double _minimizedDesktopDialogMaxWidth = 420.0;
 
 enum LockType {
   priority,
@@ -91,35 +95,41 @@ class QuickAddTaskDialog extends StatefulWidget {
 
     Future<T?> showDialogFuture;
     if (isMobile) {
-      showDialogFuture = showMaterialModalBottomSheet<T>(
-        context: context,
-        isDismissible: true,
-        enableDrag: true,
-        useRootNavigator: false,
-        expand: false,
-        builder: (BuildContext context) {
-          return AnimatedPadding(
-            padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
-            duration: const Duration(milliseconds: 100),
-            curve: Curves.easeInOut,
-            child: dialog,
-          );
-        },
+      final minimizeController = SheetMinimizeController();
+
+      showDialogFuture = Navigator.of(context, rootNavigator: false).push(
+        MinimizableSheetRoute<T>(
+          minimizeController: minimizeController,
+          isDismissible: true,
+          enableDrag: true,
+          expanded: false,
+          barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+          containerBuilder: buildMaterialSheetContainer(context),
+          builder: (BuildContext context) {
+            return SheetMinimizeScope(
+              controller: minimizeController,
+              child: AnimatedPadding(
+                padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
+                duration: const Duration(milliseconds: 100),
+                curve: Curves.easeInOut,
+                child: dialog,
+              ),
+            );
+          },
+        ),
       );
     } else {
-      showDialogFuture = showDialog<T>(
-        context: context,
-        barrierDismissible: true,
-        builder: (BuildContext context) => Dialog(
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(AppTheme.containerBorderRadius),
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                maxWidth: AppTheme.dialogMaxWidthMedium,
-                maxHeight: MediaQuery.of(context).size.height * 0.8,
-              ),
-              child: dialog,
-            ),
+      final minimizeController = SheetMinimizeController();
+
+      showDialogFuture = Navigator.of(context, rootNavigator: true).push(
+        MinimizableDialogRoute<T>(
+          minimizeController: minimizeController,
+          context: context,
+          themes: InheritedTheme.capture(from: context, to: Navigator.of(context, rootNavigator: true).context),
+          barrierDismissible: true,
+          builder: (BuildContext context) => SheetMinimizeScope(
+            controller: minimizeController,
+            child: _buildDesktopDialogShell(context, minimizeController, dialog),
           ),
         ),
       );
@@ -155,6 +165,36 @@ class QuickAddTaskDialog extends StatefulWidget {
       );
       return null;
     });
+  }
+
+  /// Wraps the desktop dialog so it collapses to a small floating bar in the
+  /// bottom-right corner instead of staying a centred, full-size dialog.
+  static Widget _buildDesktopDialogShell(
+    BuildContext context,
+    SheetMinimizeController minimizeController,
+    Widget dialog,
+  ) {
+    return AnimatedBuilder(
+      animation: minimizeController,
+      builder: (BuildContext context, _) {
+        final isMinimized = minimizeController.isMinimized;
+
+        return Dialog(
+          alignment: isMinimized ? Alignment.bottomRight : null,
+          insetPadding: EdgeInsets.all(isMinimized ? AppTheme.sizeXLarge : AppTheme.sizeLarge),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(AppTheme.containerBorderRadius),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: isMinimized ? _minimizedDesktopDialogMaxWidth : AppTheme.dialogMaxWidthMedium,
+                maxHeight: MediaQuery.sizeOf(context).height * 0.8,
+              ),
+              child: dialog,
+            ),
+          ),
+        );
+      },
+    );
   }
 
   @override
@@ -476,10 +516,24 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
     );
   }
 
+  /// Collapses the sheet and drops the keyboard so the content behind is usable.
+  void _minimize() {
+    final minimizeController = SheetMinimizeScope.maybeOf(context);
+    if (minimizeController == null) return;
+
+    _focusNode.unfocus();
+    FocusScope.of(context).unfocus();
+    minimizeController.minimize();
+  }
+
+  void _restore() => SheetMinimizeScope.maybeOf(context)?.restore();
+
   @override
   Widget build(BuildContext context) {
     final isMobile = defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS;
     final theme = Theme.of(context);
+    final minimizeController = SheetMinimizeScope.maybeOf(context);
+    final isMinimized = minimizeController?.isMinimized ?? false;
 
     return Container(
       decoration: BoxDecoration(
@@ -493,24 +547,35 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (isMobile) _buildMobileDragHandle(theme) else _buildDesktopHeader(theme),
-            _buildTitleInput(theme, isMobile),
+            if (isMobile)
+              _buildMobileDragHandle(theme)
+            else
+              // Offstage keeps the collapsed desktop bar compact; the header
+              // holds no user input, so removing it from layout is safe.
+              Offstage(offstage: isMinimized, child: _buildDesktopHeader(theme)),
+            _buildTitleInput(theme, isMobile, isMinimized),
+            // Offstage (not a conditional child) keeps the action bar mounted while
+            // minimized, so tag/priority/date selections survive the collapse.
             Flexible(
-              child: Padding(
-                padding: EdgeInsets.only(top: AppTheme.sizeSmall),
-                child: SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  child: QuickActionButtonsBar(
-                    controller: _controller,
-                    descriptionController: _descriptionController,
-                    onShowPriorityDialog: _showPrioritySelectionDialog,
-                    onShowEstimatedTimeDialog: _showEstimatedTimeDialog,
-                    onShowDescriptionDialog: _showDescriptionDialog,
-                    onSelectPlannedDate: _selectPlannedDate,
-                    onSelectDeadlineDate: _selectDeadlineDate,
-                    onClearAllFields: _onClearAllFields,
-                    tagLockAction: _buildLockAction(() => _controller.lockTags, () => _toggleLock(LockType.tags)),
-                    isMobile: isMobile,
+              child: Offstage(
+                offstage: isMinimized,
+                child: Padding(
+                  padding: EdgeInsets.only(top: AppTheme.sizeSmall),
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: QuickActionButtonsBar(
+                      controller: _controller,
+                      descriptionController: _descriptionController,
+                      onShowPriorityDialog: _showPrioritySelectionDialog,
+                      onShowEstimatedTimeDialog: _showEstimatedTimeDialog,
+                      onShowDescriptionDialog: _showDescriptionDialog,
+                      onSelectPlannedDate: _selectPlannedDate,
+                      onSelectDeadlineDate: _selectDeadlineDate,
+                      onClearAllFields: _onClearAllFields,
+                      tagLockAction: _buildLockAction(() => _controller.lockTags, () => _toggleLock(LockType.tags)),
+                      isMobile: isMobile,
+                      onMinimize: minimizeController == null ? null : _minimize,
+                    ),
                   ),
                 ),
               ),
@@ -552,11 +617,11 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
     );
   }
 
-  Widget _buildTitleInput(ThemeData theme, bool isMobile) {
+  Widget _buildTitleInput(ThemeData theme, bool isMobile, bool isMinimized) {
     return TextField(
       controller: _titleController,
       focusNode: _focusNode,
-      autofocus: true,
+      autofocus: !isMinimized,
       style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurface),
       decoration: InputDecoration(
         hintText: _controller.translationService.translate(TaskTranslationKeys.quickTaskTitlePlaceholder),
@@ -564,12 +629,31 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
         suffixIcon: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
+            if (isMinimized) _buildRestoreButton(theme),
             _buildOpenTaskButton(theme, isMobile),
             _buildSendButton(theme, isMobile),
           ],
         ),
       ),
       onSubmitted: (_) => _createTask(),
+    );
+  }
+
+  Widget _buildRestoreButton(ThemeData theme) {
+    return SizedBox(
+      width: AppTheme.buttonSizeLarge,
+      height: AppTheme.buttonSizeLarge,
+      child: IconButton(
+        icon: Icon(Icons.open_in_full, color: theme.colorScheme.onSurface.withValues(alpha: 0.7)),
+        onPressed: _restore,
+        iconSize: AppTheme.iconSizeMedium,
+        padding: EdgeInsets.zero,
+        constraints: BoxConstraints(
+          minWidth: AppTheme.buttonSizeLarge,
+          minHeight: AppTheme.buttonSizeLarge,
+        ),
+        tooltip: _controller.translationService.translate(TaskTranslationKeys.quickTaskRestore),
+      ),
     );
   }
 

--- a/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog.dart
+++ b/src/lib/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog.dart
@@ -94,9 +94,9 @@ class QuickAddTaskDialog extends StatefulWidget {
     );
 
     Future<T?> showDialogFuture;
-    if (isMobile) {
-      final minimizeController = SheetMinimizeController();
+    final minimizeController = SheetMinimizeController(false);
 
+    if (isMobile) {
       showDialogFuture = Navigator.of(context, rootNavigator: false).push(
         MinimizableSheetRoute<T>(
           minimizeController: minimizeController,
@@ -104,7 +104,7 @@ class QuickAddTaskDialog extends StatefulWidget {
           enableDrag: true,
           expanded: false,
           barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-          containerBuilder: buildMaterialSheetContainer(context),
+          containerBuilder: buildMaterialSheetContainer(),
           builder: (BuildContext context) {
             return SheetMinimizeScope(
               controller: minimizeController,
@@ -119,8 +119,6 @@ class QuickAddTaskDialog extends StatefulWidget {
         ),
       );
     } else {
-      final minimizeController = SheetMinimizeController();
-
       showDialogFuture = Navigator.of(context, rootNavigator: true).push(
         MinimizableDialogRoute<T>(
           minimizeController: minimizeController,
@@ -164,7 +162,7 @@ class QuickAddTaskDialog extends StatefulWidget {
         stackTrace: stackTrace,
       );
       return null;
-    });
+    }).whenComplete(minimizeController.dispose);
   }
 
   /// Wraps the desktop dialog so it collapses to a small floating bar in the
@@ -553,9 +551,11 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
               // Offstage keeps the collapsed desktop bar compact; the header
               // holds no user input, so removing it from layout is safe.
               Offstage(offstage: isMinimized, child: _buildDesktopHeader(theme)),
-            _buildTitleInput(theme, isMobile, isMinimized),
-            // Offstage (not a conditional child) keeps the action bar mounted while
-            // minimized, so tag/priority/date selections survive the collapse.
+            _buildTitleInput(theme, isMobile),
+            // Offstage rather than a conditional child: keeping the bar mounted
+            // avoids rebuilding it and re-running TagSelectDropdown's tag query
+            // on every collapse. The entered values themselves are safe either
+            // way - they live in the controller, not in these widgets.
             Flexible(
               child: Offstage(
                 offstage: isMinimized,
@@ -617,7 +617,9 @@ class _QuickAddTaskDialogState extends State<QuickAddTaskDialog> {
     );
   }
 
-  Widget _buildTitleInput(ThemeData theme, bool isMobile, bool isMinimized) {
+  Widget _buildTitleInput(ThemeData theme, bool isMobile) {
+    final isMinimized = SheetMinimizeScope.maybeOf(context)?.isMinimized ?? false;
+
     return TextField(
       controller: _titleController,
       focusNode: _focusNode,

--- a/src/lib/presentation/ui/features/tasks/constants/task_translation_keys.dart
+++ b/src/lib/presentation/ui/features/tasks/constants/task_translation_keys.dart
@@ -45,6 +45,8 @@ class TaskTranslationKeys extends application.TaskTranslationKeys {
   static const String taskAddedSuccessfully = 'tasks.quick_task.task_added_successfully';
   static const String quickTaskLock = 'tasks.quick_task.tooltips.lock';
   static const String quickTaskUnlock = 'tasks.quick_task.tooltips.unlock';
+  static const String quickTaskMinimize = 'tasks.quick_task.tooltips.minimize';
+  static const String quickTaskRestore = 'tasks.quick_task.tooltips.restore';
 
   // Estimated Time Dialog
   static const String estimatedTimeDescription = 'tasks.estimated_time.description';

--- a/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_background_interaction_test.dart
+++ b/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_background_interaction_test.dart
@@ -148,8 +148,7 @@ void main() {
 
         final offsetAfterRestore = scrollController.offset;
         await dragBackgroundList(tester);
-        expect(scrollController.offset, offsetAfterRestore,
-            reason: 'barrier must block scrolling again after restore');
+        expect(scrollController.offset, offsetAfterRestore, reason: 'barrier must block scrolling again after restore');
       });
     });
   }

--- a/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_background_interaction_test.dart
+++ b/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_background_interaction_test.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whph/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog.dart';
+import 'package:whph/presentation/ui/features/tasks/constants/task_translation_keys.dart';
+import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
+
+import 'quick_add_task_dialog_test_doubles.dart';
+
+/// A host page that stands in for a real list page behind the dialog.
+///
+/// Both affordances are deliberately placed near the top of the screen, where
+/// neither the bottom sheet nor the collapsed desktop bar can cover them, so a
+/// blocked interaction can only be the modal barrier's doing.
+class _BackgroundHostPage extends StatelessWidget {
+  const _BackgroundHostPage({
+    required this.scrollController,
+    required this.onBackgroundButtonPressed,
+  });
+
+  final ScrollController scrollController;
+  final VoidCallback onBackgroundButtonPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          SizedBox(
+            height: 60,
+            child: Center(
+              child: ElevatedButton(
+                onPressed: onBackgroundButtonPressed,
+                child: const Text('background-button'),
+              ),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              controller: scrollController,
+              itemCount: 60,
+              itemExtent: 50,
+              itemBuilder: (context, index) => SizedBox(
+                height: 50,
+                child: Center(child: Text('background-item-$index')),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+void main() {
+  setUpAll(installFakeContainer);
+
+  setUp(() => AppTheme.resetService());
+
+  /// Runs [body] under [platform] and clears the override before the test body
+  /// returns, because the framework asserts foundation debug vars are unset the
+  /// moment the body completes - earlier than any `tearDown` would run.
+  Future<void> withPlatform(TargetPlatform platform, Future<void> Function() body) async {
+    debugDefaultTargetPlatformOverride = platform;
+    try {
+      await body();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  }
+
+  /// Drives the real [QuickAddTaskDialog.show] and returns probes for the
+  /// background list offset and the background button tap count.
+  Future<({ScrollController scrollController, int Function() tapCount})> showDialogOverBackground(
+    WidgetTester tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(900, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    var backgroundTaps = 0;
+
+    late BuildContext hostContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            hostContext = context;
+            return _BackgroundHostPage(
+              scrollController: scrollController,
+              onBackgroundButtonPressed: () => backgroundTaps++,
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    QuickAddTaskDialog.show<String>(context: hostContext);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(QuickAddTaskDialog), findsOneWidget);
+
+    return (scrollController: scrollController, tapCount: () => backgroundTaps);
+  }
+
+  /// Drags upward over the background list, well clear of the dialog surface.
+  Future<void> dragBackgroundList(WidgetTester tester) async {
+    await tester.dragFrom(const Offset(450, 200), const Offset(0, -200));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapBackgroundButton(WidgetTester tester) async {
+    await tester.tap(find.text('background-button'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapTooltip(WidgetTester tester, String tooltip) async {
+    await tester.tap(find.byTooltip(tooltip));
+    await tester.pumpAndSettle();
+  }
+
+  /// The whole point of minimizing is that the page behind becomes usable
+  /// again, so assert on the page behind - not just on the dialog's own state.
+  ///
+  /// Scrolling carries the blocked/unblocked/blocked cycle because a drag is
+  /// non-destructive; a tap on the barrier would dismiss the dialog and end the
+  /// scenario, so tap blocking gets its own test below.
+  void runBackgroundScrollTest(String platformLabel, TargetPlatform platform) {
+    testWidgets('$platformLabel: background list scrolls only while minimized', (WidgetTester tester) async {
+      await withPlatform(platform, () async {
+        final probes = await showDialogOverBackground(tester);
+        final scrollController = probes.scrollController;
+
+        await dragBackgroundList(tester);
+        expect(scrollController.offset, 0.0, reason: 'barrier must block scrolling while expanded');
+
+        await tapTooltip(tester, TaskTranslationKeys.quickTaskMinimize);
+
+        await dragBackgroundList(tester);
+        expect(scrollController.offset, greaterThan(0.0), reason: 'background list must scroll while minimized');
+
+        await tapBackgroundButton(tester);
+        expect(probes.tapCount(), 1, reason: 'background button must be tappable while minimized');
+
+        await tapTooltip(tester, TaskTranslationKeys.quickTaskRestore);
+
+        final offsetAfterRestore = scrollController.offset;
+        await dragBackgroundList(tester);
+        expect(scrollController.offset, offsetAfterRestore,
+            reason: 'barrier must block scrolling again after restore');
+      });
+    });
+  }
+
+  /// Tapping the background while expanded must reach the barrier, not the
+  /// button - the barrier then dismisses the dialog, which is itself the proof
+  /// that it owned the pointer.
+  void runBackgroundTapBlockedTest(String platformLabel, TargetPlatform platform) {
+    testWidgets('$platformLabel: background button is unreachable while expanded', (WidgetTester tester) async {
+      await withPlatform(platform, () async {
+        final probes = await showDialogOverBackground(tester);
+
+        await tapBackgroundButton(tester);
+
+        expect(probes.tapCount(), 0, reason: 'barrier must block taps while expanded');
+        expect(find.byType(QuickAddTaskDialog), findsNothing, reason: 'the barrier consumed the tap and dismissed');
+      });
+    });
+  }
+
+  group('QuickAddTaskDialog background interaction while minimized', () {
+    runBackgroundScrollTest('mobile', TargetPlatform.android);
+    runBackgroundScrollTest('desktop', TargetPlatform.linux);
+    runBackgroundTapBlockedTest('mobile', TargetPlatform.android);
+    runBackgroundTapBlockedTest('desktop', TargetPlatform.linux);
+
+    testWidgets('desktop dialog state survives minimize and restore', (WidgetTester tester) async {
+      await withPlatform(TargetPlatform.linux, () async {
+        await showDialogOverBackground(tester);
+
+        await tester.enterText(find.byType(TextField).first, 'Desktop draft');
+        await tester.pumpAndSettle();
+
+        final stateBeforeMinimize = tester.state(find.byType(QuickAddTaskDialog));
+
+        await tapTooltip(tester, TaskTranslationKeys.quickTaskMinimize);
+        await tapTooltip(tester, TaskTranslationKeys.quickTaskRestore);
+
+        expect(tester.state(find.byType(QuickAddTaskDialog)), same(stateBeforeMinimize));
+        expect(find.text('Desktop draft'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_minimize_test.dart
+++ b/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_minimize_test.dart
@@ -3,8 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:whph/presentation/ui/features/tasks/components/quick_add_task_dialog/components/quick_action_buttons_bar.dart';
 import 'package:whph/presentation/ui/features/tasks/components/quick_add_task_dialog/minimizable_routes.dart';
 import 'package:whph/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog.dart';
+import 'package:whph/presentation/ui/features/tags/constants/tag_ui_constants.dart';
 import 'package:whph/presentation/ui/features/tasks/constants/task_translation_keys.dart';
 import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
+import 'package:whph/presentation/ui/shared/constants/shared_translation_keys.dart';
 import 'quick_add_task_dialog_test_doubles.dart';
 
 void main() {
@@ -38,9 +40,8 @@ void main() {
   }
 
   group('QuickAddTaskDialog minimize/restore', () {
-    testWidgets('preserves typed title and dialog state across minimize and restore',
-        (WidgetTester tester) async {
-      final minimizeController = SheetMinimizeController();
+    testWidgets('preserves typed title and dialog state across minimize and restore', (WidgetTester tester) async {
+      final minimizeController = SheetMinimizeController(false);
       addTearDown(minimizeController.dispose);
 
       await pumpDialog(tester, minimizeController);
@@ -70,8 +71,81 @@ void main() {
       expect(find.byType(QuickActionButtonsBar), findsOneWidget);
     });
 
+    testWidgets('preserves a selected tag across minimize and restore', (WidgetTester tester) async {
+      final minimizeController = SheetMinimizeController(false);
+      addTearDown(minimizeController.dispose);
+
+      await pumpDialog(tester, minimizeController);
+
+      // The tag picker opens a full dialog; the default narrow sheet surface
+      // overflows its action row and the tap would land on a clipped widget.
+      await tester.binding.setSurfaceSize(const Size(900, 900));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(TagUiConstants.tagIcon).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(stubTagNames.first).last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(SharedTranslationKeys.doneButton).last);
+      await tester.pumpAndSettle();
+
+      // The tooltip renders the selected tag names, so its presence proves the
+      // dropdown really holds a selection - otherwise the assertion after the
+      // cycle would pass vacuously.
+      expect(find.byTooltip(stubTagNames.first), findsOneWidget);
+
+      await tester.tap(find.byTooltip(TaskTranslationKeys.quickTaskMinimize));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip(TaskTranslationKeys.quickTaskRestore));
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip(stubTagNames.first), findsOneWidget);
+    });
+
+    testWidgets('preserves a typed description across minimize and restore', (WidgetTester tester) async {
+      final minimizeController = SheetMinimizeController(false);
+      addTearDown(minimizeController.dispose);
+
+      await pumpDialog(tester, minimizeController);
+
+      await tester.tap(find.byIcon(Icons.description_outlined));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, 'Two litres, semi-skimmed');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(SharedTranslationKeys.doneButton).last);
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.description), findsOneWidget,
+          reason: 'the description must actually be set, otherwise the assertion below is vacuous');
+
+      await tester.tap(find.byTooltip(TaskTranslationKeys.quickTaskMinimize));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip(TaskTranslationKeys.quickTaskRestore));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.description), findsOneWidget);
+    });
+
+    testWidgets('releases focus when minimized so the keyboard does not cover the page', (WidgetTester tester) async {
+      final minimizeController = SheetMinimizeController(false);
+      addTearDown(minimizeController.dispose);
+
+      await pumpDialog(tester, minimizeController);
+
+      await tester.tap(find.byType(TextField).first);
+      await tester.pumpAndSettle();
+      expect(tester.testTextInput.isVisible, isTrue, reason: 'the keyboard must be up before minimizing');
+
+      await tester.tap(find.byTooltip(TaskTranslationKeys.quickTaskMinimize));
+      await tester.pumpAndSettle();
+
+      // A minimized sheet under an open keyboard would hide the page it just
+      // uncovered, defeating the point of minimizing.
+      expect(tester.testTextInput.isVisible, isFalse);
+    });
+
     testWidgets('keeps the action bar mounted while minimized', (WidgetTester tester) async {
-      final minimizeController = SheetMinimizeController();
+      final minimizeController = SheetMinimizeController(false);
       addTearDown(minimizeController.dispose);
 
       await pumpDialog(tester, minimizeController);
@@ -84,8 +158,7 @@ void main() {
       expect(find.byType(QuickActionButtonsBar), findsNothing);
     });
 
-    testWidgets('hides the minimize affordance when no SheetMinimizeScope is present',
-        (WidgetTester tester) async {
+    testWidgets('hides the minimize affordance when no SheetMinimizeScope is present', (WidgetTester tester) async {
       await tester.binding.setSurfaceSize(const Size(420, 900));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 

--- a/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_minimize_test.dart
+++ b/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_minimize_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whph/presentation/ui/features/tasks/components/quick_add_task_dialog/components/quick_action_buttons_bar.dart';
+import 'package:whph/presentation/ui/features/tasks/components/quick_add_task_dialog/minimizable_routes.dart';
+import 'package:whph/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog.dart';
+import 'package:whph/presentation/ui/features/tasks/constants/task_translation_keys.dart';
+import 'package:whph/presentation/ui/shared/constants/app_theme.dart';
+import 'quick_add_task_dialog_test_doubles.dart';
+
+void main() {
+  setUpAll(installFakeContainer);
+
+  setUp(() => AppTheme.resetService());
+
+  /// Pumps the real [QuickAddTaskDialog] inside a [SheetMinimizeScope], which is
+  /// exactly how the mobile route hosts it. No production logic is reimplemented.
+  Future<void> pumpDialog(
+    WidgetTester tester,
+    SheetMinimizeController minimizeController,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(420, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: SheetMinimizeScope(
+              controller: minimizeController,
+              child: const QuickAddTaskDialog(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('QuickAddTaskDialog minimize/restore', () {
+    testWidgets('preserves typed title and dialog state across minimize and restore',
+        (WidgetTester tester) async {
+      final minimizeController = SheetMinimizeController();
+      addTearDown(minimizeController.dispose);
+
+      await pumpDialog(tester, minimizeController);
+
+      await tester.enterText(find.byType(TextField).first, 'Buy milk');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Buy milk'), findsOneWidget);
+      expect(find.byType(QuickActionButtonsBar), findsOneWidget);
+
+      final stateBeforeMinimize = tester.state(find.byType(QuickAddTaskDialog));
+
+      await tester.tap(find.byTooltip(TaskTranslationKeys.quickTaskMinimize));
+      await tester.pumpAndSettle();
+
+      expect(minimizeController.isMinimized, isTrue);
+      expect(find.byTooltip(TaskTranslationKeys.quickTaskRestore), findsOneWidget);
+
+      await tester.tap(find.byTooltip(TaskTranslationKeys.quickTaskRestore));
+      await tester.pumpAndSettle();
+
+      expect(minimizeController.isMinimized, isFalse);
+
+      // Regression guard: the State was never recreated, so no input was lost.
+      expect(tester.state(find.byType(QuickAddTaskDialog)), same(stateBeforeMinimize));
+      expect(find.text('Buy milk'), findsOneWidget);
+      expect(find.byType(QuickActionButtonsBar), findsOneWidget);
+    });
+
+    testWidgets('keeps the action bar mounted while minimized', (WidgetTester tester) async {
+      final minimizeController = SheetMinimizeController();
+      addTearDown(minimizeController.dispose);
+
+      await pumpDialog(tester, minimizeController);
+
+      await tester.tap(find.byTooltip(TaskTranslationKeys.quickTaskMinimize));
+      await tester.pumpAndSettle();
+
+      // Offstage (rather than removal) is what makes state survival structural.
+      expect(find.byType(QuickActionButtonsBar, skipOffstage: false), findsOneWidget);
+      expect(find.byType(QuickActionButtonsBar), findsNothing);
+    });
+
+    testWidgets('hides the minimize affordance when no SheetMinimizeScope is present',
+        (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(420, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.bottomCenter,
+              child: QuickAddTaskDialog(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Desktop hosts the dialog without the scope; the button must not appear.
+      expect(find.byTooltip(TaskTranslationKeys.quickTaskMinimize), findsNothing);
+    });
+  });
+}

--- a/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_test_doubles.dart
+++ b/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_test_doubles.dart
@@ -1,0 +1,118 @@
+import 'package:acore/acore.dart' hide Container;
+import 'package:flutter/material.dart';
+import 'package:mediatr/mediatr.dart';
+import 'package:mockito/mockito.dart';
+import 'package:whph/core/domain/features/tags/tag.dart';
+import 'package:whph/core/domain/features/tasks/task.dart';
+import 'package:whph/core/domain/shared/constants/app_theme.dart' as domain;
+import 'package:whph/main.dart' as app_main;
+import 'package:whph/core/application/features/tags/services/abstraction/i_tag_repository.dart';
+import 'package:whph/core/application/features/tags/queries/get_list_tags_query.dart';
+import 'package:whph/core/application/features/tasks/services/abstraction/i_task_recurrence_service.dart';
+import 'package:whph/presentation/ui/features/tasks/services/abstraction/i_default_task_settings_service.dart';
+import 'package:whph/presentation/ui/features/tasks/services/tasks_service.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service.dart';
+import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
+import 'package:whph/presentation/ui/shared/utils/error_helper.dart';
+
+
+class MockTranslationService extends Mock implements ITranslationService {
+  @override
+  String translate(String key, {Map<String, String>? namedArgs, String? defaultValue}) => key;
+}
+
+class MockThemeService extends Mock implements IThemeService {
+  @override
+  Color get primaryColor => Colors.blue;
+  @override
+  Color get textColor => Colors.black;
+  @override
+  Color get secondaryTextColor => Colors.grey;
+  @override
+  Color get surface1 => Colors.grey.shade100;
+  @override
+  Color get surface2 => Colors.grey.shade200;
+  @override
+  Color get surface3 => Colors.grey.shade300;
+  @override
+  domain.UiDensity get currentUiDensity => domain.UiDensity.normal;
+}
+
+class FakeDefaultTaskSettingsService extends Fake implements IDefaultTaskSettingsService {
+  @override
+  Future<int?> getDefaultEstimatedTime() async => null;
+
+  @override
+  Future<(ReminderTime, int?)> getDefaultPlannedDateReminder() async => (ReminderTime.none, null);
+}
+
+class FakeTagRepository extends Fake implements ITagRepository {
+  @override
+  Future<Tag?> getById(String id, {bool includeDeleted = false}) async => null;
+}
+
+class FakeTaskRecurrenceService extends Fake implements ITaskRecurrenceService {}
+
+class FakeLogger extends Fake implements ILogger {
+  @override
+  void debug(String message, [Object? error, StackTrace? stackTrace, String? component]) {}
+  @override
+  void info(String message, [Object? error, StackTrace? stackTrace, String? component]) {}
+  @override
+  void warning(String message, [Object? error, StackTrace? stackTrace, String? component]) {}
+  @override
+  void error(String message, [Object? error, StackTrace? stackTrace, String? component]) {}
+  @override
+  void fatal(String message, [Object? error, StackTrace? stackTrace, String? component]) {}
+}
+
+class FakeContainer extends Fake implements IContainer {
+  final Mediator mediator = Mediator(Pipeline());
+  final MockTranslationService translationService = MockTranslationService();
+  final MockThemeService themeService = MockThemeService();
+  final FakeTagRepository tagRepository = FakeTagRepository();
+  final FakeDefaultTaskSettingsService defaultTaskSettingsService = FakeDefaultTaskSettingsService();
+  late final TasksService tasksService = TasksService(
+    FakeTaskRecurrenceService(),
+    mediator,
+    FakeLogger(),
+  );
+
+  @override
+  T resolve<T>([String? name]) {
+    if (T == Mediator) return mediator as T;
+    if (T == ITranslationService) return translationService as T;
+    if (T == IThemeService) return themeService as T;
+    if (T == ITagRepository) return tagRepository as T;
+    if (T == TasksService) return tasksService as T;
+    if (T == IDefaultTaskSettingsService) return defaultTaskSettingsService as T;
+    throw UnimplementedError('FakeContainer.resolve($T)');
+  }
+}
+
+/// Returns an empty tag page so [TagSelectDropdown] can settle without a database.
+class StubGetListTagsQueryHandler implements IRequestHandler<GetListTagsQuery, GetListTagsQueryResponse> {
+  @override
+  Future<GetListTagsQueryResponse> call(GetListTagsQuery request) async {
+    return GetListTagsQueryResponse(
+      items: const [],
+      totalItemCount: 0,
+      pageIndex: request.pageIndex,
+      pageSize: request.pageSize,
+    );
+  }
+}
+
+/// Wires the fake DI container the dialog resolves its services from.
+///
+/// Call once per test file from `setUpAll`; the returned container is also
+/// installed as the global `app_main.container`.
+FakeContainer installFakeContainer() {
+  final fakeContainer = FakeContainer();
+  app_main.container = fakeContainer;
+  ErrorHelper.initialize(fakeContainer.translationService);
+  fakeContainer.mediator.registerHandler<GetListTagsQuery, GetListTagsQueryResponse, StubGetListTagsQueryHandler>(
+    () => StubGetListTagsQueryHandler(),
+  );
+  return fakeContainer;
+}

--- a/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_test_doubles.dart
+++ b/src/test/presentation/ui/features/tasks/components/quick_add_task_dialog/quick_add_task_dialog_test_doubles.dart
@@ -15,7 +15,6 @@ import 'package:whph/presentation/ui/shared/services/abstraction/i_theme_service
 import 'package:whph/presentation/ui/shared/services/abstraction/i_translation_service.dart';
 import 'package:whph/presentation/ui/shared/utils/error_helper.dart';
 
-
 class MockTranslationService extends Mock implements ITranslationService {
   @override
   String translate(String key, {Map<String, String>? namedArgs, String? defaultValue}) => key;
@@ -90,13 +89,25 @@ class FakeContainer extends Fake implements IContainer {
   }
 }
 
+/// Tags the stub handler serves.
+///
+/// Non-empty on purpose: an empty list makes [TagSelectDropdown]'s selection
+/// path unreachable, so any test asserting that a chosen tag survives a
+/// minimize/restore cycle would pass vacuously.
+const stubTagNames = ['Work', 'Home'];
+
 /// Returns an empty tag page so [TagSelectDropdown] can settle without a database.
 class StubGetListTagsQueryHandler implements IRequestHandler<GetListTagsQuery, GetListTagsQueryResponse> {
   @override
   Future<GetListTagsQueryResponse> call(GetListTagsQuery request) async {
+    final items = <TagListItem>[
+      for (var index = 0; index < stubTagNames.length; index++)
+        TagListItem(id: 'tag-$index', name: stubTagNames[index]),
+    ];
+
     return GetListTagsQueryResponse(
-      items: const [],
-      totalItemCount: 0,
+      items: items,
+      totalItemCount: items.length,
       pageIndex: request.pageIndex,
       pageSize: request.pageSize,
     );


### PR DESCRIPTION
### 🚀 Context

Composing a task blocked the list behind it, so users could not glance at a related task to jog their memory while typing.

> This is the first of two remaining items from the multi-topic feedback in #215. The other four topics in that issue (tag color picker, tag deletion, tag dropdown, create-and-open) are already resolved in the current codebase.

This PR adds a **minimize** action to the Quick Add Task dialog. Collapsing the dialog hands input back to the page underneath, so the task list can be scrolled and tapped while a draft task stays intact.

#### 🔗 Related

- Relates to #215

---

### ⚙️ Implementation Details

#### Dropping the barrier, not the route

A modal route intercepts pointers through the `ModalBarrier` built by `ModalRoute.buildModalBarrier()`. Both hosts get a subclass that yields that barrier while minimized:

| Host | Route | Base |
|---|---|---|
| Mobile bottom sheet | `MinimizableSheetRoute` | `ModalSheetRoute` |
| Desktop dialog | `MinimizableDialogRoute` | `DialogRoute` |

`DialogRoute` is a `PopupRoute`, so `opaque` is already `false` — the route below stays mounted and painted. The barrier was the only thing blocking input, so removing it is sufficient; no second navigator or overlay is involved.

```mermaid
stateDiagram-v2
    [*] --> Expanded: show()
    Expanded --> Minimized: minimize()
    Minimized --> Expanded: restore()
    Expanded --> [*]: create / dismiss

    note right of Expanded
        ModalBarrier present
        background inert
    end note

    note right of Minimized
        barrier yields SizedBox.shrink()
        background scrollable + tappable
        route still on the stack
    end note
```

#### Preserving what the user typed

> [!IMPORTANT]
> Minimizing never calls `Navigator.pop()`. All dialog state — title, description, tags, priority, estimated time, dates, lock toggles — lives in `_QuickAddTaskDialogState`, which would be disposed with the route.

Two details carry that guarantee:

- **The route stays on the stack**, so the `State` object is never recreated.
- **The action bar is wrapped in `Offstage`, not a conditional child.** Unmounting `QuickActionButtonsBar` would destroy `TagSelectDropdown`'s internal selection; `Offstage` keeps it mounted and merely excluded from hit testing.

#### Wiring

`SheetMinimizeController` (a `ChangeNotifier`) is owned by the code that pushes the route, so it outlives content rebuilds. `SheetMinimizeScope` (an `InheritedNotifier`) carries it to the dialog. Its **absence** is what hides the minimize affordance on a host that cannot collapse — no dead button is ever rendered.

The file was renamed `minimizable_sheet_route.dart` → `minimizable_routes.dart`, since it now holds both routes.

#### Tests

Beyond asserting state survival, the suite proves the feature's actual purpose — that the background becomes usable — for **both** hosts:

| State | Asserted |
|---|---|
| Expanded | `scrollController.offset == 0.0`; background button `tapCount == 0` |
| Minimized | `offset > 0.0`; `tapCount == 1` |
| Restored | Barrier blocks again |
| Across the cycle | `same(stateBeforeMinimize)`; typed text still present |

New user-facing strings (`minimize` / `restore`) are translated across all 22 locales.

---

### 📋 Checklist for Reviewer

- [x] Tests passed locally — full suite, 2420 tests green; `flutter analyze` clean on changed files.
- [x] Commit history is clean and descriptive.
- [ ] Documentation updated (if applicable) — N/A, no user-facing docs cover this dialog.
- [x] Code quality standards met (e.g., linter passed).

> [!NOTE]
> **Verification limit — worth a manual pass.** The desktop binary builds and runs, but I could not raise its window programmatically under Wayland, so this was never exercised by hand. Correctness rests on the widget tests above, which drive the real routes and measure the intended behavior directly. A single manual try on desktop before merge would close that gap.

> [!TIP]
> 29 files sounds large, but 22 are one-line locale additions. The reviewable surface is `minimizable_routes.dart` (new, 119 lines), `quick_add_task_dialog.dart`, and the three test files.
